### PR TITLE
Fix benchmarking output from browsers

### DIFF
--- a/bin/browser
+++ b/bin/browser
@@ -1,3 +1,3 @@
 #!/bin/bash
 DIR=`dirname $0`
-node $DIR/../built/src/runInBrowser --env browser $@
+node $DIR/../built/src/runInBrowser $@

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -18,7 +18,7 @@ const transform = args.transform;
 
 const validTransforms = [ 'eager', 'lazy', 'retval', 'original' ];
 if (validTransforms.includes(transform) === false) {
-  stderr.write(`--transform must be one of ${validTransforms.join(', ')}`);
+  stderr.write(`--transform must be one of ${validTransforms.join(', ')}, got ${transform}.\n`);
   process.exit(1);
 }
 if (typeof srcPath === 'undefined') {

--- a/src/runInBrowser.ts
+++ b/src/runInBrowser.ts
@@ -34,9 +34,8 @@ const driver = new selenium.Builder()
 driver.get(src);
 driver.wait(selenium.until.titleIs('done'), 5 * 60 * 1000) .then(_ =>
   driver.findElement(selenium.By.id('data')).then(e =>
-    e.getText().then(s => {
-      stdout.write(s.slice(2, s.length) + '\n');
-
+    e.getAttribute("value").then(s => {
+      stdout.write(s);
       driver.quit();
       if (vfb) {
         vfb.stopSync();

--- a/src/runtime/default.ts
+++ b/src/runtime/default.ts
@@ -52,16 +52,8 @@ export function parseRuntimeOpts(rawArgs: string[], filename?: string): Opts {
     yieldInterval = NaN;
   }
 
-  let execEnv : 'browser' | 'node';
-  if (typeof args.env !== 'string') {
-    execEnv = 'node';
-  } else if (args.env === 'browser') {
-    execEnv = 'browser';
-  } else if (args.env === 'node') {
-    execEnv = 'node';
-  } else {
-    throw new Error(`--env must be either 'browser' or 'node'`);
-  }
+  let execEnv: 'node' | 'browser' = 
+    typeof window === 'undefined' ? 'node' : 'browser';
 
   return { 
     filename: filename, 
@@ -94,13 +86,12 @@ export function run(M: Stoppable, opts: Opts, done: () => void): void {
   }
 
   if (opts.env === 'browser') {
-    console.log = function (data: any) {
-      var div = document.getElementById('data')!;
-      div.innerHTML = div.innerHTML + ", " + data;
+    const data = <HTMLTextAreaElement>document.getElementById('data')!;
+    console.log = function (str: any) {
+      data.value = data.value + str + '\n';
     }
     window.onerror = () => {
-      var div = document.getElementById('data')!;
-      div.innerHTML = `, Failed`
+      data.value = data.value + ',NA\n';
       window.document.title = "done"
     }
   }

--- a/src/webpack/webpack.ts
+++ b/src/webpack/webpack.ts
@@ -53,7 +53,7 @@ webpack(webpackConfig, (err, stats) => {
   }  
 
   const out = fs.openSync(dstPage, 'w');
-  fs.writeSync(out, "<html><body><div id='data'></div><script>\n");
+  fs.writeSync(out, "<html><body><textarea id='data'></textarea><script>\n");
   fs.writeSync(out, fs.readFileSync(outputJs.name, 'utf8'));
   fs.writeSync(out, "\n</script></body></html>\n");
   fs.closeSync(out);


### PR DESCRIPTION
- Auto-detect the environment so we can run a webpacked program by
  opening in the browser (without /run/browser).
- Output to a <textarea> instead of a <div> to preserve newlines