### PR TITLE
Added a fudged transformation

### DIFF
--- a/src/callcc/fudgeRuntime.ts
+++ b/src/callcc/fudgeRuntime.ts
@@ -1,0 +1,62 @@
+import * as common from './runtime';
+export * from './runtime';
+
+class FudgedContinuationError {
+  
+  constructor(public v: any) { }
+
+  toString() {
+    return `FudgedContinuationError(${this.v})`;
+  }  
+
+}
+
+/** This runtime system doesn't actually implement any control operators.
+ * Functions such as 'captureCC' are defined and will call their argument, 
+ * but don't save the stack.
+ * 
+ * Unfortunately, all our program end by invoking the top continuation with
+ * "done". Therefore, a program that runs correctly will terminate with
+ * 'FudgedContinuationError(done)'. This is unfortunate. But, this
+ * transformation still helps with debugging.
+ */
+export class FudgeRuntime extends common.Runtime {
+  constructor() {
+    super();
+  }
+
+  captureCC(f: (k: any) => any): void {
+    throw new common.Capture(f, []);
+  }
+
+  abortCC(f: () => any) {
+    throw new common.Discard(f);
+  }
+
+  makeCont(stack: common.Stack) {
+    return (v: any) => {
+      throw new FudgedContinuationError(v);
+    };
+  }
+
+  runtime(body: () => any): any {
+    try {
+      body();
+    }
+    catch (exn) {
+      if (exn instanceof common.Capture) {
+        return this.runtime(() => exn.f.call(global, this.makeCont(exn.stack)));
+      } else if (exn instanceof common.Discard) {
+        return this.runtime(() => exn.f());
+      } else {
+        throw exn; // userland exception
+      }
+    }
+  }
+
+  handleNew(constr: any, ...args: any[]) {
+    return new constr(...args);
+  }
+}
+
+export default FudgeRuntime;

--- a/src/callcc/jumper.ts
+++ b/src/callcc/jumper.ts
@@ -12,7 +12,7 @@ type Labeled<T> = T & {
 }
 type CaptureFun = (path: NodePath<t.AssignmentExpression>) => void;
 
-export type CaptureLogic = 'lazy' | 'eager' | 'retval';
+export type CaptureLogic = 'lazy' | 'eager' | 'retval' | 'fudge';
 
 interface State {
   opts: {
@@ -24,6 +24,7 @@ const captureLogics: { [key: string]: CaptureFun } = {
   lazy: lazyCaptureLogic,
   eager: eagerCaptureLogic,
   retval: retvalCaptureLogic,
+  fudge: fudgeCaptureLogic,
 };
 
 function split<T>(arr: T[], index: number): { pre: T[], post: T[] } {
@@ -173,6 +174,10 @@ function reapplyExpr(path: NodePath<Labeled<t.Function>>): t.Expression {
       t.memberExpression(funId, t.identifier("call")),
       [t.thisExpression(), ...<any>path.node.params]);
   }
+}
+
+function fudgeCaptureLogic(path: NodePath<t.AssignmentExpression>): void {
+  return;
 }
 
 /**

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -16,7 +16,7 @@ const srcPath = args._[0];
 const dstPath = args._[1];
 const transform = args.transform;
 
-const validTransforms = [ 'eager', 'lazy', 'retval', 'original' ];
+const validTransforms = [ 'eager', 'lazy', 'retval', 'original', 'fudge' ];
 if (validTransforms.includes(transform) === false) {
   stderr.write(`--transform must be one of ${validTransforms.join(', ')}, got ${transform}.\n`);
   process.exit(1);

--- a/src/rts.ts
+++ b/src/rts.ts
@@ -4,6 +4,7 @@ import { Runtime, YieldInterval, Latency } from './callcc/runtime';
 import eager from './callcc/eagerRuntime';
 import lazy from './callcc/lazyRuntime';
 import retval from './callcc/retvalRuntime';
+import fudge from './callcc/fudgeRuntime';
 
 function modeToBase(mode: string) {
  if (mode === 'eager') {
@@ -14,6 +15,9 @@ function modeToBase(mode: string) {
   }
   else if (mode === 'retval') {
     return retval;
+  }
+  else if (mode === 'fudge') {
+    return fudge;
   }
   else {
     throw new Error(`unknown runtime system mode: ${mode}`);


### PR DESCRIPTION
Many Stopify bugs are found in the transformations that occur before
jumper. However, jumper makes the generated code very hard to debug.
This transformation does everything except inserting logic to save
and restore the stack around function calls. It will only work with
"-y 0". In addition, successful programs terminate by throwing
the exception "FudgedContinuationError(done)".