### PR TITLE
Allow directly calling captureCC in transformed code

### DIFF
--- a/stopify/src/callcc/callcc.ts
+++ b/stopify/src/callcc/callcc.ts
@@ -108,7 +108,9 @@ const visitor: Visitor = {
     toShift.unshift(
       h.letExpression(
         t.identifier("captureCC"),
-        t.memberExpression(t.identifier("$__R"), t.identifier("captureCC")),
+        t.callExpression(
+          t.memberExpression(t.memberExpression(t.identifier("$__R"),
+            t.identifier("captureCC")), t.identifier("bind")), [$__R]),
         "const"));
     toShift.unshift(
       h.letExpression(

--- a/stopify/src/callcc/stopifyCallCC.ts
+++ b/stopify/src/callcc/stopifyCallCC.ts
@@ -23,7 +23,8 @@ const allowed = [
   "global",
   "window",
   "document",
-  "setTimeout"
+  "setTimeout",
+  "captureCC",
 ];
 
 const reserved = [
@@ -37,6 +38,7 @@ const reserved = [
   "frame",
   "SENTINAL",
   "finally_rv",
+  "captureCC",
 ];
 
 export const visitor: Visitor = {


### PR DESCRIPTION
This allows transforming javascript code that directly uses
```
captureCC(...)
```
where `captureCC` is a free identifier in the program.