### PR TITLE
Webpack req'd files from node_modules with bin/compile

### DIFF
--- a/stopify/src/compile.ts
+++ b/stopify/src/compile.ts
@@ -97,7 +97,7 @@ if (args.webpack) {
       test: /\.js$/,
       // NOTE(arjun): This is a small hack. We don't transform files
       // that end with .exclude.js, such as the loader created above.
-      exclude: /(\.exclude\.js$|node_modules)/,
+      exclude: /(\.exclude\.js$)/,
       loader: 'babel-loader',
       options: {
           plugins: [plugin],


### PR DESCRIPTION
@arjunguha @rachitnigam Does this look alright?

I can make it a command line flag if we want, but this allows us to `bin/compile` bucklescript programs with `--webpack` and stopify the deps without double webpacking, which causes issues.