### PR TITLE
Reduce renaming of function identifiers

### DIFF
--- a/stopify/src/callcc/boxAssignables.ts
+++ b/stopify/src/callcc/boxAssignables.ts
@@ -91,6 +91,7 @@ function liftStatement(parentPath: NodePath<Parent>, path: NodePath<t.Node>,
 
 
 function enterFunction(self: State, path: NodePath<t.FunctionExpression>) {
+
     const locals = Set.of(...Object.keys(path.scope.bindings));
     // Mutable variables from this scope that are not shadowed
     const vars0 = self.vars.subtract(locals);
@@ -207,7 +208,7 @@ const visitor = {
         (<any>fun).boxedArgs = (<any>path.node).boxedArgs;
 
         // Little hack necessary to preserve annotation left by freeIds.ts
-        (<any>fun).nestedFunctionFree = (<any>path.node).nestedFunctionFree;
+        (<any>fun).escapingAIds = (<any>path.node).escapingAIds;
         const stmt = t.variableDeclaration("var",
           [t.variableDeclarator(path.node.id, box(fun))]);
         liftStatement(parentPath, path, stmt);

--- a/stopify/src/callcc/boxAssignables.ts
+++ b/stopify/src/callcc/boxAssignables.ts
@@ -48,7 +48,7 @@ function shouldBox(x: string, path: NodePath<t.Function | t.Program>): boolean {
       path.node.id.name === x) {
     return false;
   }
-  return (<any>binds[x].kind === "hoisted" || freeIds.isNestedFree(path, x));
+  return (freeIds.isNestedFree(path, x));
 }
 
 function liftStatement(parentPath: NodePath<Parent>, path: NodePath<t.Node>,
@@ -198,6 +198,7 @@ const visitor = {
       // signature.
       if (vars.includes(path.node.id.name) &&
           !(state.opts.compileFunction && (<any>path.node).topFunction)) {
+        console.log(`Doing it to ${path.node.id.name} ${vars}`);
         const fun = t.functionExpression(
           fastFreshId.fresh('fun'),
           path.node.params,

--- a/stopify/src/callcc/boxAssignables.ts
+++ b/stopify/src/callcc/boxAssignables.ts
@@ -198,7 +198,6 @@ const visitor = {
       // signature.
       if (vars.includes(path.node.id.name) &&
           !(state.opts.compileFunction && (<any>path.node).topFunction)) {
-        console.log(`Doing it to ${path.node.id.name} ${vars}`);
         const fun = t.functionExpression(
           fastFreshId.fresh('fun'),
           path.node.params,

--- a/stopify/src/callcc/callcc.ts
+++ b/stopify/src/callcc/callcc.ts
@@ -12,6 +12,7 @@ import * as desugarSwitch from '../common/desugarSwitch';
 import * as desugarLogical from '../common/desugarLogical';
 import * as singleVarDecls from '../common/singleVarDecls';
 import * as makeBlocks from '../common/makeBlockStmt';
+import * as scopeAnalysis from '../scopeAnalysis';
 import * as boxAssignables from './boxAssignables';
 import * as desugarNew from '../common/desugarNew';
 import * as anf from '../common/anf';
@@ -55,6 +56,8 @@ const visitor: Visitor = {
 
     timeSlow('singleVarDecl', () =>
       h.transformFromAst(path, [singleVarDecls]));
+    timeSlow('scopeAnalysis', () =>
+      h.transformFromAst(path, [scopeAnalysis.plugin]));
     timeSlow('free ID initialization', () =>
       freeIds.annotate(path));
     timeSlow('box assignables', () =>

--- a/stopify/src/callcc/delimitTopLevel.ts
+++ b/stopify/src/callcc/delimitTopLevel.ts
@@ -48,6 +48,9 @@ const visitor = {
           decl.init = delimitExpr(decl.init);
         }
       }
+      else if (stmt.type === 'FunctionDeclaration') {
+        // leave intact
+      }
       else {
         if (state.opts.compileFunction && (<any>body[i]).topFunction) {
         }

--- a/stopify/src/callcc/nameExprs.ts
+++ b/stopify/src/callcc/nameExprs.ts
@@ -13,14 +13,16 @@ const names: Visitor = {
   FunctionExpression: function (path: NodePath<t.FunctionExpression>): void {
     if (path.node.id === undefined || path.node.id === null) {
       path.node.id = fastFreshId.fresh('funExpr');
-    } else if (path.scope.hasOwnBinding(path.node.id.name)) {
+    } else if (path.scope.hasOwnBinding(path.node.id.name) &&
+      <any>path.scope.bindings[path.node.id.name].kind != 'local') {
       const new_id = fastFreshId.fresh('funExpr');
       path.scope.rename(path.node.id.name, new_id.name);
     }
   },
 
   FunctionDeclaration: function (path: NodePath<t.FunctionDeclaration>): void {
-    if (path.scope.hasOwnBinding(path.node.id.name)) {
+    if (path.scope.hasOwnBinding(path.node.id.name) &&
+      <any>path.scope.bindings[path.node.id.name].kind != 'local') {
       const new_id = fastFreshId.fresh('funExpr');
       path.scope.rename(path.node.id.name, new_id.name);
     }

--- a/stopify/src/callcc/nameExprs.ts
+++ b/stopify/src/callcc/nameExprs.ts
@@ -13,13 +13,23 @@ const names: Visitor = {
   FunctionExpression: function (path: NodePath<t.FunctionExpression>): void {
     if (path.node.id === undefined || path.node.id === null) {
       path.node.id = fastFreshId.fresh('funExpr');
-    } else if (path.scope.hasOwnBinding(path.node.id.name) &&
+    }
+    /*
+     * This deals with the following kind of code:
+     *
+     *   function F() { var F; }
+     *
+     * We need to able to reference F within its body to restore its stack
+     * frame. Therefore, we rename the local variable F.
+     */
+    else if (path.scope.hasOwnBinding(path.node.id.name) &&
       <any>path.scope.bindings[path.node.id.name].kind != 'local') {
-      const new_id = fastFreshId.fresh('funExpr');
+      const new_id = fastFreshId.fresh('x');
       path.scope.rename(path.node.id.name, new_id.name);
     }
   },
-
+  // NOTE(arjun): Dead code? I think no FunctionDeclarations exist at this
+  // point.
   FunctionDeclaration: function (path: NodePath<t.FunctionDeclaration>): void {
     if (path.scope.hasOwnBinding(path.node.id.name) &&
       <any>path.scope.bindings[path.node.id.name].kind != 'local') {

--- a/stopify/src/scopeAnalysis.ts
+++ b/stopify/src/scopeAnalysis.ts
@@ -1,0 +1,91 @@
+/**
+ * This module annotates the Program and every Function with (a) its
+ * free identifiers and (2) its local assignable identifiers.
+ */
+import * as t from 'babel-types';
+import * as babel from 'babel-core';
+import { NodePath, Visitor } from 'babel-traverse';
+import { Set } from 'immutable';
+
+export type T = {
+  assignableIds: Set<string>,
+  freeIds: Set<string>
+}
+
+type S = {
+  referencedIds: Set<string>,
+  assignedIds: Set<string>,
+  referencedIdsStack: Set<string>[],
+  assignedIdsStack: Set<string>[],
+}
+
+function genericEnter(self: S, node: t.Node & T) {
+  self.referencedIdsStack.push(self.referencedIds);
+  self.assignedIdsStack.push(self.assignedIds);
+  self.referencedIds = Set<string>();
+  self.assignedIds = Set<string>();
+}
+
+function genericExit(self: S, locals: Set<string>, node: t.Node & T) {
+  node.freeIds = self.referencedIds.subtract(locals);
+  node.assignableIds = self.assignedIds.subtract(node.freeIds);
+  self.referencedIds = self.referencedIdsStack.pop()!;
+  self.assignedIds = self.assignedIdsStack.pop()!;
+}
+
+
+const visitor = {
+  ReferencedIdentifier(this: S, path: NodePath<t.Identifier>) {
+    const parentType = path.parent.type;
+    if (parentType === "BreakStatement" ||
+        parentType === 'ContinueStatement' ||
+        parentType === "LabeledStatement") {
+      return;
+    }
+    this.referencedIds = this.referencedIds.add(path.node.name);
+  },
+  AssignmentExpression(this: S, path: NodePath<t.AssignmentExpression>) {
+    if (path.node.left.type !== 'Identifier') {
+      return;
+    }
+    this.assignedIds = this.assignedIds.add(path.node.left.name);
+  },
+  ObjectMethod: {
+    enter(this: S, path: NodePath<t.ObjectMethod & T>) {
+      genericEnter(this, path.node);
+    },
+    exit(this: S, path: NodePath<t.ObjectMethod & T>) {
+      genericExit(this, Set(Object.keys(path.scope.bindings)), path.node);
+    }
+  },
+  FunctionExpression: {
+    enter(this: S, path: NodePath<t.FunctionExpression & T>) {
+      genericEnter(this, path.node);
+    },
+    exit(this: S, path: NodePath<t.FunctionExpression & T>) {
+      genericExit(this, Set(Object.keys(path.scope.bindings)), path.node);
+    }
+  },
+  FunctionDeclaration: {
+    enter(this: S, path: NodePath<t.FunctionDeclaration & T>) {
+      genericEnter(this, path.node);
+    },
+    exit(this: S, path: NodePath<t.FunctionDeclaration & T>) {
+      genericExit(this, Set(Object.keys(path.scope.bindings)), path.node);
+    }
+  },
+  Program: {
+    enter(this: S, path: NodePath<t.Program & T>) {
+      this.referencedIdsStack = [];
+      this.assignedIdsStack = [];
+      this.referencedIds = Set<string>();
+      this.assignedIds = Set<string>();
+    },
+    exit(this: S, path: NodePath<t.Program & T>) {
+      genericExit(this, Set(Object.keys(path.scope.bindings)), path.node);
+    }
+  }
+}
+export function plugin() {
+  return { visitor };
+}

--- a/stopify/test/should-run/assign-before-var.js
+++ b/stopify/test/should-run/assign-before-var.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+
+var XXX = 999;
+function MYOUTERFUNC() {
+  INNER_FUNCTION(undefined);
+  XXX = 5;
+  function INNER_FUNCTION(expected) {
+    assert(XXX === expected);
+  }
+
+  INNER_FUNCTION(5);
+  var XXX = 20;
+  
+  INNER_FUNCTION(20);
+}
+
+MYOUTERFUNC();
+assert(XXX === 999);


### PR DESCRIPTION
This reduces renaming in two ways
 - `boxAssignables` was generating a new identifier for every `FunctionDeclaration` (they all get boxed). This now reuses the original identifier for the `FunctionExpression` that gets allocated in the box.
 - `nameExprs` used to rename every `FunctionExpression` again because `hasOwnBinding` includes the id bound by the function expression itself. This now filters out `local` bindings, which correspond to the function identifier.