### PR TITLE
Add the ability to restart a continuation with an exception

### DIFF
--- a/stopify-continuations/src/runtime/abstractRuntime.ts
+++ b/stopify-continuations/src/runtime/abstractRuntime.ts
@@ -35,37 +35,37 @@ export class Restore {
   constructor(public stack: Stack) {}
 }
 
-// We throw this exception to capture the current continuation. i.e.,
-// captureCC throws this exception when it is applied. This class needs to be
-// exported because source programs are instrumented to catch it.
+// This class is used by all the runtimes to start the stack capturing process.
 export class Capture {
   constructor(public f: (k: any) => any, public stack: Stack) {}
 }
 
-// TODO(rachit): Is this still used?
-export interface RuntimeInterface {
-  captureCC(f: (k: any) => any): void;
-  // Wraps a stack in a function that throws an exception to discard the current
-  // continuation. The exception carries the provided stack with a final frame
-  // that returns the supplied value. If err is provided, instead of returning
-  // the supplied value, it throws an exception with the provided error
-  makeCont(stack: Stack): (v: any, err?: any) => any;
-  runtime(body: () => any): any;
-  handleNew(constr: any, ...args: any[]): any;
-  abstractRun(body: () => any): RunResult;
-}
-
 export abstract class Runtime {
+  // The runtime stack.
   stack: Stack;
+
+  // Mode of the program. `true` represents 'normal' mode while `false`
+  // represents 'restore' mode.
   mode: Mode;
+
+  noErrorProvided: any = {};
+
   linenum: undefined | number;
 
   constructor(
+    // True when the instrumented program is capturing the stack.
     public capturing: boolean = false,
+
+    /**
+     * Represents the level of nesting in the runtime. Crucially, if the
+     * delimitDepth > 1, then stopify does not allow the program to suspend.
+     */
     public delimitDepth: number = 0,
-    // true if computation is suspended by 'suspend'
+
+    // true if computation is suspended by 'suspend'.
     public isSuspended: boolean = false,
-    // a queue of computations that need to run
+
+    // a queue of computations that need to be run.
     private pendingRuns: (() => void)[] = []) {
     this.stack = [];
     this.mode = true;
@@ -80,17 +80,16 @@ export abstract class Runtime {
   resumeFromSuspension(thunk: () => any): any {
     this.isSuspended = false;
     this.runtime_(thunk);
-    this.resume();
+    return this.resume();
   }
 
-  /**
-   * Evaluates 'thunk' either now or later.
-   */
+  // Queues the thunk to be processed by the runtime.
+  // If there are no other processes running, it is invoked immediately.
   delimit(thunk: () => any): any {
     if (this.isSuspended === false) {
       this.runtime_(thunk);
       if (this.delimitDepth === 0) {
-        this.resume();
+        return this.resume();
       }
     }
     else {
@@ -98,11 +97,15 @@ export abstract class Runtime {
     }
   }
 
+  // Try to resume the program. If the program has been suspended externally,
+  // this does nothing. Otherwise, it runs the next function in the queue.
   resume(): any {
     if (this.isSuspended) {
       return;
     }
     if (this.pendingRuns.length > 0) {
+
+      // TODO(rachit): Don't use shift here. It is slow.
       return this.delimit(this.pendingRuns.shift()!);
     }
   }
@@ -118,6 +121,7 @@ export abstract class Runtime {
     };
   }
 
+  // TODO(rachit): Document this.
   runtime(body: () => any): any {
     while (true) {
       const result = this.abstractRun(body)
@@ -144,12 +148,30 @@ export abstract class Runtime {
     }
   }
 
+  // Called when the stack needs to be captured.
   abstract captureCC(f: (k: any) => any): void;
-  // Wraps a stack in a function that throws an exception to discard the current
-  // continuation. The exception carries the provided stack with a final frame
-  // that returns the supplied value.
-  abstract makeCont(stack: Stack): (v: any) => any;
+
+  /**
+   * Wraps a stack in a function that throws an exception to discard the
+   * current continuation. The exception carries the provided stack with a
+   * final frame that returns the supplied value. If err is provided, instead
+   * of returning the supplied value, it throws an exception with the provided
+   * error.
+   */
+  abstract makeCont(stack: Stack): (v: any, err: any) => any;
+
+  // Used by instrumented programs to suspend correctly from inside a
+  // constructor call.
   abstract handleNew(constr: any, ...args: any[]): any;
+
+  /**
+   * Run the `body`. It can return four types of values (in the form RunResult):
+   *
+   * 'normal': The execution of the body terminated normally.
+   * 'capture': The execution of the body resulted in a stack capturing operation.
+   * 'restore': The execution of the body resulted in a stack restoration operation.
+   * 'exception': The excution of the body resulted in a userland exception.
+   */
   abstract abstractRun(body: () => any): RunResult;
 }
 

--- a/stopify-continuations/src/runtime/abstractRuntime.ts
+++ b/stopify-continuations/src/runtime/abstractRuntime.ts
@@ -47,8 +47,9 @@ export interface RuntimeInterface {
   captureCC(f: (k: any) => any): void;
   // Wraps a stack in a function that throws an exception to discard the current
   // continuation. The exception carries the provided stack with a final frame
-  // that returns the supplied value.
-  makeCont(stack: Stack): (v: any) => any;
+  // that returns the supplied value. If err is provided, instead of returning
+  // the supplied value, it throws an exception with the provided error
+  makeCont(stack: Stack): (v: any, err?: any) => any;
   runtime(body: () => any): any;
   handleNew(constr: any, ...args: any[]): any;
   abstractRun(body: () => any): RunResult;

--- a/stopify-continuations/src/runtime/eagerRuntime.ts
+++ b/stopify-continuations/src/runtime/eagerRuntime.ts
@@ -1,6 +1,7 @@
 import * as common from './abstractRuntime';
 export * from './abstractRuntime';
 
+var noErrorProvided = {};
 export class EagerRuntime extends common.Runtime {
   eagerStack: common.Stack;
 
@@ -15,9 +16,14 @@ export class EagerRuntime extends common.Runtime {
   }
 
   makeCont(stack: common.Stack) {
-    return (v: any) => {
+    return (v: any, err: any=noErrorProvided) => {
+      var throwExn = err !== noErrorProvided;
+      let restarter = () => {
+        if(throwExn) { throw err; }
+        else { return v; }
+      }
       this.eagerStack = [...stack];
-      throw new common.Restore([this.topK(() => v), ...stack]);
+      throw new common.Restore([this.topK(restarter), ...stack]);
     }
   }
 

--- a/stopify-continuations/src/runtime/eagerRuntime.ts
+++ b/stopify-continuations/src/runtime/eagerRuntime.ts
@@ -1,7 +1,6 @@
 import * as common from './abstractRuntime';
 export * from './abstractRuntime';
 
-var noErrorProvided = {};
 export class EagerRuntime extends common.Runtime {
   eagerStack: common.Stack;
 
@@ -16,8 +15,8 @@ export class EagerRuntime extends common.Runtime {
   }
 
   makeCont(stack: common.Stack) {
-    return (v: any, err: any=noErrorProvided) => {
-      var throwExn = err !== noErrorProvided;
+    return (v: any, err: any=this.noErrorProvided) => {
+      var throwExn = err !== this.noErrorProvided;
       let restarter = () => {
         if(throwExn) { throw err; }
         else { return v; }

--- a/stopify-continuations/src/runtime/lazyRuntime.ts
+++ b/stopify-continuations/src/runtime/lazyRuntime.ts
@@ -1,7 +1,6 @@
 import * as common from './abstractRuntime';
 export * from './abstractRuntime';
 
-var noErrorProvided = {};
 export class LazyRuntime extends common.Runtime {
   constructor() {
     super();
@@ -14,8 +13,9 @@ export class LazyRuntime extends common.Runtime {
 
   makeCont(stack: common.Stack) {
     const savedDelimitDepth = this.delimitDepth;
-    return (v: any, err: any=noErrorProvided) => {
-      var throwExn = err !== noErrorProvided;
+
+    return (v: any, err: any=this.noErrorProvided) => {
+      const throwExn = err !== this.noErrorProvided;
       this.delimitDepth = savedDelimitDepth;
       let restarter = () => {
         if(throwExn) { throw err; }

--- a/stopify-continuations/src/runtime/lazyRuntime.ts
+++ b/stopify-continuations/src/runtime/lazyRuntime.ts
@@ -1,6 +1,7 @@
 import * as common from './abstractRuntime';
 export * from './abstractRuntime';
 
+var noErrorProvided = {};
 export class LazyRuntime extends common.Runtime {
   constructor() {
     super();
@@ -13,9 +14,14 @@ export class LazyRuntime extends common.Runtime {
 
   makeCont(stack: common.Stack) {
     const savedDelimitDepth = this.delimitDepth;
-    return (v: any) => {
+    return (v: any, err: any=noErrorProvided) => {
+      var throwExn = err !== noErrorProvided;
       this.delimitDepth = savedDelimitDepth;
-      throw new common.Restore([this.topK(() => v), ...stack]);
+      let restarter = () => {
+        if(throwExn) { throw err; }
+        else { return v; }
+      }
+      throw new common.Restore([this.topK(restarter), ...stack]);
     };
   }
 

--- a/stopify-continuations/src/runtime/retvalRuntime.ts
+++ b/stopify-continuations/src/runtime/retvalRuntime.ts
@@ -11,9 +11,15 @@ export class RetvalRuntime extends common.Runtime {
     return new common.Capture(f, []);
   }
 
-  makeCont(stack: common.Stack): (v: any) => common.Restore {
-    return (v: any) =>
-      new common.Restore([this.topK(() => v), ...stack]);
+  makeCont(stack: common.Stack) {
+    return (v: any, err: any = this.noErrorProvided) => {
+      const throwExn = err !== this.noErrorProvided;
+      let restarter = () => {
+        if (throwExn) { throw err; }
+        else { return v; }
+      }
+      return new common.Restore([this.topK(restarter), ...stack]);
+    }
   }
 
   abstractRun(body: () => any): common.RunResult {

--- a/stopify-continuations/test-data/capture-restore-with-exn.js
+++ b/stopify-continuations/test-data/capture-restore-with-exn.js
@@ -1,0 +1,27 @@
+var assert = require('assert');
+
+function restartWithExn() {
+  try {
+    f();
+  }
+  catch(e) {
+    return e;
+  }
+}
+
+function f() {
+  return captureCC(function(k) {
+    return g(k);
+  });
+}
+
+function g(k) {
+  return k(null, "throw-this");
+}
+
+var result = restartWithExn();
+
+console.log("Result of restart:", result);
+
+assert(result == "throw-this");
+

--- a/stopify-continuations/test-data/capture-restore-with-exn.js
+++ b/stopify-continuations/test-data/capture-restore-with-exn.js
@@ -1,3 +1,6 @@
+/**
+ * This tests restarting a captured continuation by throwing a value.
+ */
 var assert = require('assert');
 
 function restartWithExn() {
@@ -15,6 +18,8 @@ function f() {
   });
 }
 
+// `k` is a function returned by `makeCont` in the Runtime class.
+// k : (v: any, err?: any) => any
 function g(k) {
   return k(null, "throw-this");
 }


### PR DESCRIPTION
I'd be happy to hear a better approach than the noErrorProvided pattern. The
goal is to make it so that `null` and `undefined` are OK values to throw,
because that might actually matter in some programs, where here,
noErrorProvided is unique to these implementations.