### PR TITLE
Move all var decls to the top

### DIFF
--- a/stopify-continuations/src/babelHelpers.ts
+++ b/stopify-continuations/src/babelHelpers.ts
@@ -4,6 +4,11 @@ import * as t from 'babel-types';
 export type FunWithBody = t.FunctionDeclaration | t.FunctionExpression |
   t.ObjectMethod;
 
+export function isFunWithBody(node: t.Node): node is FunWithBody {
+  return t.isFunctionDeclaration(node) || t.isFunctionExpression(node) ||
+    t.isObjectMethod(node);
+}
+
 export const eTrue = t.booleanLiteral(true);
 
 export const eFalse = t.booleanLiteral(false);

--- a/stopify-continuations/src/callcc/declVars.ts
+++ b/stopify-continuations/src/callcc/declVars.ts
@@ -1,25 +1,69 @@
 /**
+ * Assumes that singleVarDecls has run before this and handled all the `let`
+ * and `const` declarations.
+ *
  * Moves var statements to the top of functions.
  *
  * When a var is moved, it is initialized to undefined. The
  * transformation introduces assignment statements where the var statement
  * originally occurred.
  */
-import { NodePath, Visitor } from 'babel-traverse';
 import * as t from 'babel-types';
+import * as bh from '../babelHelpers';
+import { NodePath, Visitor } from 'babel-traverse';
 import {tag} from '../common/helpers';
 
 type Lifted<T> = T & {
   lifted?: boolean
 };
+
+type TopDecl<T> = T & {
+  decls?: Array<t.Identifier>
+}
+
 const lifted = <T>(t: T) => tag('lifted', t, true);
 
+const funWithBody = {
+  enter (path: NodePath<TopDecl<bh.FunWithBody>>) {
+    path.node.decls = [];
+  },
+  exit (path: NodePath<TopDecl<bh.FunWithBody>>) {
+    if (path.node.decls!.length > 0) {
+      const decl = t.variableDeclaration('var',
+        path.node.decls!.map(id => t.variableDeclarator(id)));
+      path.node.body.body.unshift(decl);
+    }
+  }
+}
+
 const lift: Visitor = {
+  Program: {
+    enter(path: NodePath<TopDecl<t.Program>>) {
+      path.node.decls = [];
+    },
+    exit(path: NodePath<TopDecl<t.Program>>) {
+      if (path.node.decls!.length > 0) {
+        const decl = t.variableDeclaration('var',
+          path.node.decls!.map(id => t.variableDeclarator(id)));
+        path.node.body.unshift(decl);
+      }
+    },
+  },
+  FunctionDeclaration: funWithBody,
+  FunctionExpression: funWithBody,
+  ObjectMethod: funWithBody,
   VariableDeclaration(path: NodePath<Lifted<t.VariableDeclaration>>) {
     if (path.node.lifted) {
       return;
     }
-    let { declarations } = path.node;
+    const { declarations } = path.node;
+    let fParent = path.getFunctionParent().node;
+
+    if (!bh.isFunWithBody(fParent) && !t.isProgram(fParent)) {
+      throw new Error(
+        `Variable declarations should be inside a function. Parent was ${path.node.type}`);
+    }
+
     const stmts: t.Statement[] = [];
 
     if ((<any>declarations[0]).__boxVarsInit__) {
@@ -30,9 +74,9 @@ const lift: Visitor = {
       if (decl.id.type !== 'Identifier') {
         throw new Error(`Destructuring assignment not supported`);
       }
-      const newDecl = t.variableDeclaration('var',
-                        [t.variableDeclarator(decl.id)]);
-      stmts.push(lifted(newDecl));
+
+      (fParent as TopDecl<bh.FunWithBody | t.Program>).decls!.push(lifted(decl.id));
+
       if (decl.init !== null) {
         // If we call path.insertAfter here, we will add assignments in reverse
         // order. Fortunately, path.replaceWithMultiple can take an array of nodes.

--- a/stopify-continuations/src/callcc/declVars.ts
+++ b/stopify-continuations/src/callcc/declVars.ts
@@ -11,17 +11,10 @@
 import * as t from 'babel-types';
 import * as bh from '../babelHelpers';
 import { NodePath, Visitor } from 'babel-traverse';
-import {tag} from '../common/helpers';
-
-type Lifted<T> = T & {
-  lifted?: boolean
-};
 
 type TopDecl<T> = T & {
   decls?: Array<t.Identifier>
-}
-
-const lifted = <T>(t: T) => tag('lifted', t, true);
+};
 
 const funWithBody = {
   enter (path: NodePath<TopDecl<bh.FunWithBody>>) {
@@ -34,7 +27,7 @@ const funWithBody = {
       path.node.body.body.unshift(decl);
     }
   }
-}
+};
 
 const lift: Visitor = {
   Program: {
@@ -52,10 +45,7 @@ const lift: Visitor = {
   FunctionDeclaration: funWithBody,
   FunctionExpression: funWithBody,
   ObjectMethod: funWithBody,
-  VariableDeclaration(path: NodePath<Lifted<t.VariableDeclaration>>) {
-    if (path.node.lifted) {
-      return;
-    }
+  VariableDeclaration(path: NodePath<t.VariableDeclaration>) {
     const { declarations } = path.node;
     let fParent = path.getFunctionParent().node;
 
@@ -75,7 +65,7 @@ const lift: Visitor = {
         throw new Error(`Destructuring assignment not supported`);
       }
 
-      (fParent as TopDecl<bh.FunWithBody | t.Program>).decls!.push(lifted(decl.id));
+      (fParent as TopDecl<bh.FunWithBody | t.Program>).decls!.push(decl.id);
 
       if (decl.init !== null) {
         // If we call path.insertAfter here, we will add assignments in reverse

--- a/stopify-continuations/src/callcc/jumper.ts
+++ b/stopify-continuations/src/callcc/jumper.ts
@@ -315,7 +315,6 @@ const jumper = {
       func(path, state);
 
       const declTarget = bh.varDecl(target, t.nullLiteral());
-      (<any>declTarget).lifted = true;
       path.node.body.body.unshift(declTarget);
 
       // Increment the remainingStack at the last line of the function.
@@ -326,7 +325,6 @@ const jumper = {
         path.node.localVars.push(newTarget);
         const declNewTarget = bh.varDecl(newTarget,
           t.memberExpression(t.identifier('new'), t.identifier('target')));
-        (<any>declNewTarget).lifted = true;
 
         path.node.body.body.unshift(declNewTarget);
 


### PR DESCRIPTION
Three changes:
- Move var decls to the top. Fixes #308 (first two commits)
- CompileFunction can take a list of known flat functions. Useful for Pyret code.
- Document deep stacks. Fixes #333.
