### PR TITLE
Events support

### DIFF
--- a/docs/examples/clicks.html
+++ b/docs/examples/clicks.html
@@ -1,0 +1,49 @@
+<html>
+<body>
+  <button id="pauseResume">Pause / Resume</button>
+  <div id="webConsole"></div>
+  <script src="../../stopify/dist/stopify-full.bundle.js"></script>
+  <script>
+    const webConsole = document.getElementById('webConsole');
+
+    var paused = false;
+    document.getElementById('pauseResume').addEventListener('click', () => {
+      if (paused) {
+        paused = false;
+        runner.resume();
+      }
+      else {
+        runner.pause(() => {
+          paused = true;
+        });
+      }
+    });
+
+    function alert(message) {
+      const div = document.createElement('div');
+      div.appendChild(document.createTextNode(message));
+      webConsole.appendChild(div);
+    }
+
+    function onClick(callback) {
+      window.addEventListener('click', evt => {
+        runner.processEvent(
+          () => callback(evt.clientX, evt.clientY),
+          () => { /* result from callback does not matter */ });
+      });
+    }
+
+    const program = `
+      onClick(function(x, y) {
+        alert('You clicked at (' + x + ', ' + y + ')');
+      });
+    `;
+
+    const runner = stopify.stopifyLocally(
+      `(function(){ ${program} })()`,
+      { externals: [ 'onClick', 'alert' ] });
+
+    runner.run(() => console.log('program complete'));
+  </script>
+</body>
+</html>

--- a/docs/illustrative_examples.rst
+++ b/docs/illustrative_examples.rst
@@ -42,3 +42,22 @@ them.
 
 This program prompts the user for two inputs without modal dialog boxes.
 
+
+External Events
+===============
+
+.. literalinclude:: examples/clicks.html
+  :language: html
+
+The ``onClick`` function in the code below is an example of an event handler
+that receives a stopified callback named ``callback``. However, ``onClick``
+cannot apply ``callback`` directly. To support suspending execution,
+``callback`` must execute in the context of Stopify's runtime system.
+
+Instead, ``onClick`` invokes Stopify's ``processEvent`` method, passing it a
+thunk that calls ``callback``. If the program is paused, ``processEvent`` queues
+the event until the program is resumed. Therefore, if the user pauses the
+program, clicks several times, and then resumes, several clicks will clicks
+will occur immediately after resumption. It is straightforward to discard
+clicks that occur while paused by testing the ``paused`` variable before
+invoking ``processEvent``.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -160,6 +160,18 @@ The ``AsyncRun`` Interface
 
 .. code-block:: typescript
 
+  interface NormalResult {
+    type: 'normal';
+    value: any;
+  }
+
+  interface ExceptionResult {
+    type: 'exception';
+    value: any;
+  };
+
+  type Result = NormalResult | ExceptionResult;
+
   interface AsyncRun {
     run(onDone: () => void,
         onYield?: () => void,
@@ -170,6 +182,7 @@ The ``AsyncRun`` Interface
     step(onStep: (line: number) => void): void;
     pauseImmediate(callback: () => void): void;
     continueImmediate(result: any): void;
+    processEvent(body: () => any, receiver: (x: Result) => void): void;
   }
 
 The ``AsyncRun`` interface provides methods to run, stop, and control the
@@ -204,6 +217,11 @@ functions to provide simulated blocking interface to the stopified program:
 
 :doc:`illustrative_examples` has several examples that use these methods to implement simulated blocking
 operations.
+
+Finally, the ``processEvent(f, onDone)`` method allows external event-handlers
+to call a stopified function ``f``. Since ``f`` may pause execution and thus
+not return immediately, Stopify passes its result to the ``onDone`` callback,
+which must not be a stopified function.
 
 The Online Compiler
 ===================

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -15,6 +15,8 @@ Stopify (working version)
 - Fixed a bug where programs that used ``return`` or ``throw`` in the
   ``default:`` case of a ``switch`` statement would not resume correctly.
 
+- Added the ``processEvent`` function to the Stopify API.
+
 Stopify 0.1.0
 =============
 

--- a/stopify-continuations/src/babelHelpers.ts
+++ b/stopify-continuations/src/babelHelpers.ts
@@ -47,7 +47,15 @@ export function and(e1: t.Expression, e2: t.Expression) {
 /** Constructs an 'e1 || e2', but simplifies when either sub-expression is
  *  a literal.
  */
-export function or(e1: t.Expression, e2: t.Expression) {
+export function or(...es: t.Expression[]): t.Expression {
+  let r = t.booleanLiteral(false) as t.Expression;
+  for (const e of es) {
+    r = orBin(r, e);
+  }
+  return r;
+}
+
+function orBin(e1: t.Expression, e2: t.Expression) {
   if ((e1.type === 'BooleanLiteral' && e1.value === false)) {
     return e2;
   }

--- a/stopify-continuations/src/callcc/captureLogics.ts
+++ b/stopify-continuations/src/callcc/captureLogics.ts
@@ -31,6 +31,7 @@ const captureLocals = t.identifier('captureLocals');
 const runtime = t.identifier('$__R');
 const runtimeStack = t.memberExpression(runtime, t.identifier('stack'));
 const captureExn = t.memberExpression(types, t.identifier('Capture'));
+export const endTurnExn = t.memberExpression(types, t.identifier('EndTurn'));
 const isNormalMode = t.memberExpression(runtime, t.identifier('mode'));
 const topOfRuntimeStack = t.memberExpression(runtimeStack,
   t.binaryExpression("-", t.memberExpression(runtimeStack, t.identifier("length")), t.numericLiteral(1)), true);

--- a/stopify-continuations/src/callcc/jumper.ts
+++ b/stopify-continuations/src/callcc/jumper.ts
@@ -12,6 +12,7 @@ import { letExpression } from '../common/helpers';
 import {
   isNormalMode,
   captureExn,
+  endTurnExn,
   captureLocals,
   target,
   restoreNextFrame,
@@ -443,7 +444,8 @@ const jumper = {
       body.body.unshift(t.ifStatement(
         bh.or(
           t.binaryExpression('instanceof', param, captureExn),
-          t.binaryExpression('instanceof', param, restoreExn)),
+          t.binaryExpression('instanceof', param, restoreExn),
+          t.binaryExpression('instanceof', param, endTurnExn)),
         t.throwStatement(param)));
       path.skip();
     }

--- a/stopify-continuations/src/runtime/eagerRuntime.ts
+++ b/stopify-continuations/src/runtime/eagerRuntime.ts
@@ -1,5 +1,6 @@
 import * as common from './abstractRuntime';
 export * from './abstractRuntime';
+import { Result } from '../types';
 
 export class EagerRuntime extends common.Runtime {
   eagerStack: common.Stack;
@@ -26,6 +27,10 @@ export class EagerRuntime extends common.Runtime {
     };
   }
 
+  endTurn(callback: (onDone: (x: Result) => any) => any): never {
+    throw new common.EndTurn(callback);
+  }
+
   abstractRun(body: () => any): common.RunResult {
     try {
       const v = body();
@@ -38,6 +43,9 @@ export class EagerRuntime extends common.Runtime {
       }
       else if (exn instanceof common.Restore) {
         return { type: 'restore', stack: exn.stack, savedStack: exn.savedStack };
+      }
+      else if (exn instanceof common.EndTurn) {
+        return { type: 'end-turn', callback: exn.callback };
       }
       else {
         return { type: 'exception', value: exn };

--- a/stopify-continuations/src/runtime/fudgeRuntime.ts
+++ b/stopify-continuations/src/runtime/fudgeRuntime.ts
@@ -1,5 +1,6 @@
 import * as common from './abstractRuntime';
 export * from './abstractRuntime';
+import { Result } from '../types';
 
 class FudgedContinuationError {
   constructor(public v: any) {}
@@ -44,6 +45,9 @@ export class FudgeRuntime extends common.Runtime {
         this.capturing = false;
         return { type: 'capture', stack: exn.stack, f: exn.f };
       }
+      else if (exn instanceof common.EndTurn) {
+        return { type: 'end-turn', callback: exn.callback };
+      }
       else {
         return { type: 'exception', value: exn };
       }
@@ -53,4 +57,9 @@ export class FudgeRuntime extends common.Runtime {
   handleNew(constr: any, ...args: any[]) {
     return new constr(...args);
   }
+
+  endTurn(callback: (onDone: (x: Result) => any) => any): never {
+    throw new common.EndTurn(callback);
+  }
+
 }

--- a/stopify-continuations/src/runtime/lazyRuntime.ts
+++ b/stopify-continuations/src/runtime/lazyRuntime.ts
@@ -1,5 +1,6 @@
 import * as common from './abstractRuntime';
 export * from './abstractRuntime';
+import { Result } from '../types';
 
 export class LazyRuntime extends common.Runtime {
   constructor(stackSize: number, restoreFrames: number) {
@@ -33,6 +34,12 @@ export class LazyRuntime extends common.Runtime {
     };
   }
 
+  endTurn(callback: (onDone: (x: Result) => any) => any): never {
+    this.savedStack = [];
+    this.stack = [];
+    throw new common.EndTurn(callback);
+  }
+
   abstractRun(body: () => any): common.RunResult {
     try {
       const v = body();
@@ -45,6 +52,9 @@ export class LazyRuntime extends common.Runtime {
       }
       else if (exn instanceof common.Restore) {
         return { type: 'restore', stack: exn.stack, savedStack: exn.savedStack };
+      }
+      else if (exn instanceof common.EndTurn) {
+        return { type: 'end-turn', callback: exn.callback };
       }
       else {
         return { type: 'exception', value: exn };

--- a/stopify-continuations/src/runtime/retvalRuntime.ts
+++ b/stopify-continuations/src/runtime/retvalRuntime.ts
@@ -1,5 +1,6 @@
 import * as common from './abstractRuntime';
 export * from './abstractRuntime';
+import { Result } from '../types';
 
 export class RetvalRuntime extends common.Runtime {
   constructor(stackSize: number, restoreFrames: number) {
@@ -34,6 +35,10 @@ export class RetvalRuntime extends common.Runtime {
     };
   }
 
+  endTurn(callback: (onDone: (x: Result) => any) => any): never {
+    throw new common.EndTurn(callback);
+  }
+
   abstractRun(body: () => any): common.RunResult {
     try {
       const v = body();
@@ -49,6 +54,9 @@ export class RetvalRuntime extends common.Runtime {
       }
     }
     catch (exn) {
+      if (exn instanceof common.EndTurn) {
+        return { type: 'end-turn', callback: exn.callback };
+      }
       return { type: 'exception', value: exn };
     }
   }

--- a/stopify-continuations/src/runtime/runtime.ts
+++ b/stopify-continuations/src/runtime/runtime.ts
@@ -10,7 +10,6 @@ import { FudgeRuntime } from './fudgeRuntime';
 export * from './sentinels';
 
 export * from './abstractRuntime';
-export * from './abstractRuntime';
 export { knownBuiltIns } from '../common/cannotCapture';
 
 let savedRTS: Runtime | undefined;

--- a/stopify-continuations/src/types.ts
+++ b/stopify-continuations/src/types.ts
@@ -16,6 +16,9 @@ export interface CompilerOpts {
   externals: string[]
 }
 
+export type Result =
+  { type: 'normal', value: any } |
+  { type: 'exception', value: any }
 
 export interface Runtime {
   // Remaining number of stacks that this runtime can consume.
@@ -29,8 +32,10 @@ export interface Runtime {
   stackSize: number;
   restoreFrames: number;
 
-  resumeFromSuspension(thunk: () => any): void;
+  resumeFromSuspension(thunk: () => any, onDone: (x: Result) => any): void;
   delimit(thunk: () => any): any;
+
+  endTurn(callback: (onDone: (x: Result) => any) => any): never;
 
   // Try to resume the program. If the program has been suspended externally,
   // this does nothing. Otherwise, it runs the next function in the queue.
@@ -38,7 +43,7 @@ export interface Runtime {
 
   // Top level function that runs a given program. Handles capture and restore
   // events that may be emitted by the program.
-  runtime(body: () => any): any;
+  runtime<T>(body: () => any, onDone: (x: Result) => T): T;
 
   // Called when the stack needs to be captured.
   captureCC(f: (k: any) => any): void;

--- a/stopify/src/types.ts
+++ b/stopify/src/types.ts
@@ -1,3 +1,5 @@
+import { Result } from 'stopify-continuations/dist/src/types';
+export { Result };
 export { HandleNew, CaptureMethod, CompilerOpts } from 'stopify-continuations';
 
 export type Stoppable = (isStop: () => boolean,
@@ -34,4 +36,5 @@ export interface AsyncRun {
   step(onStep: (line: number) => void): void;
   pauseImmediate(callback: () => void): void;
   continueImmediate(result: any): void;
+  processEvent(body: () => any, receiver: (x: Result) => void): void;
 }

--- a/stopify/test-data/integration/event-processing-blocking.html
+++ b/stopify/test-data/integration/event-processing-blocking.html
@@ -1,0 +1,55 @@
+<html>
+
+<body>
+  <p>This page runs Stopify in the browser.</p>
+<script src="../../dist/stopify-full.bundle.js"></script>
+<script>
+var program = `
+onTimeout(function() {
+  var r = sleep(40) + sleep(2);
+  console.log('Calculated r', r);
+  return r;
+});
+`;
+
+function sleep(n) {
+  runner.pauseImmediate(() => {
+    window.setTimeout(() => {
+      console.log(`sleep continuing with ${n}`);
+      runner.continueImmediate(n);
+    }, 100);
+  });
+}
+
+function onTimeout(callback) {
+  window.setTimeout(() =>
+    runner.processEvent(
+      () => callback(),
+      (result) => {
+        if (result.type === 'normal' && result.value === 42) {
+          window.document.title = 'okay';
+        }
+        else {
+          console.log("ERROR HERE", result);
+          window.document.title = 'error';
+        }
+      }), 
+    0);
+}
+
+var runner = stopify.stopifyLocally(program, {
+  externals: [ 'onTimeout', 'window', 'console', 'sleep' ]
+}, {
+  estimator: 'countdown',
+  yieldInterval: 1
+});
+
+runner.run(() => { });
+
+window.onerror = function() {
+  window.document.title = "error";
+}
+</script>
+
+</body>
+</html>

--- a/stopify/test-data/integration/event-processing-result.html
+++ b/stopify/test-data/integration/event-processing-result.html
@@ -1,0 +1,46 @@
+<html>
+
+<body>
+  <p>This page runs Stopify in the browser.</p>
+<script src="../../dist/stopify-full.bundle.js"></script>
+<script>
+var program = `
+onTimeout(function() {
+  // for (var i = 0; i < 10; i++) { }
+  console.log("going to return 42");
+  return 42;
+});
+`;
+
+function onTimeout(callback) {
+  window.setTimeout(() =>
+    runner.processEvent(
+      () => callback(),
+      (result) => {
+        if (result.type === 'normal' && result.value === 42) {
+          window.document.title = 'okay';
+        }
+        else {
+          console.log("ERROR HERE");
+          window.document.title = 'error';
+        }
+      }), 
+    0);
+}
+
+var runner = stopify.stopifyLocally(program, {
+  externals: [ 'onTimeout', 'window', 'console' ]
+}, {
+  estimator: 'countdown',
+  yieldInterval: 1
+});
+
+runner.run(() => { });
+
+window.onerror = function() {
+  window.document.title = "error";
+}
+</script>
+
+</body>
+</html>

--- a/stopify/test-data/integration/event-processing.html
+++ b/stopify/test-data/integration/event-processing.html
@@ -1,0 +1,36 @@
+<html>
+
+<body>
+  <p>This page runs Stopify in the browser.</p>
+<script src="../../dist/stopify-full.bundle.js"></script>
+<script>
+var program = `
+onTimeout(function() {
+  for (var i = 0; i < 10; i++) { }
+  onTimeout(function() {
+    for (var j = 0; j < 10; j++) { }
+    window.document.title = 'okay';
+  });
+});
+`;
+
+function onTimeout(callback) {
+  window.setTimeout(() => runner.processEvent(callback, () => {}), 0);
+}
+
+var runner = stopify.stopifyLocally(program, {
+  externals: [ 'onTimeout', 'window' ]
+}, {
+  estimator: 'countdown',
+  yieldInterval: 1
+});
+
+runner.run(() => { });
+
+window.onerror = function() {
+  window.document.title = "error";
+}
+</script>
+
+</body>
+</html>

--- a/stopify/test-data/integration/step-with-events.html
+++ b/stopify/test-data/integration/step-with-events.html
@@ -1,0 +1,81 @@
+<html>
+
+<body>
+  <p>This page runs Stopify in the browser.</p>
+<script src="../../dist/stopify-full.bundle.js"></script>
+<script>
+var paused = false;
+var i = 0;
+var program = `
+function F() {
+  onInterval(function() {
+    while (false) { }
+    if (paused) {
+      throw 'should have been paused';
+    }
+    i = i + 1;
+  });
+}
+
+F();
+`;
+
+
+function onInterval(callback) {
+  console.log(`onInterval(...)`);
+  function handler() {
+    runner.processEvent(callback,
+      (result) => {
+      if (result.type === 'exception') {
+        window.clearInterval(intervalID);
+        throw result.value;
+      }
+    });
+  }
+  var intervalID = window.setInterval(handler, 200);
+}
+
+var runner = stopify.stopifyLocally(program, {
+  externals: [ 'onInterval', 'paused', 'i', 'console' ]
+}, {
+  estimator: 'countdown',
+  yieldInterval: 1
+});
+
+runner.run((x) => {
+  console.log('end of main turn');
+});
+
+window.setTimeout(() => {
+  console.log('Starting pause 1 ...');
+  runner.pause(() => {
+    paused = true;
+    console.log('Pause 1 completed. i = ', i);
+    window.setTimeout(() => {
+      console.log('Starting resume 1. i = ', i);
+      paused = false;
+      runner.resume();
+      var iPrev = i;
+      window.setTimeout(() => {
+        console.log('Starting pause 2 ... i = ', i);
+        if (i === iPrev) {
+          throw 'i did not advance';
+        }
+        runner.pause(() => {
+          console.log('Pause 2 completed. i = ', i);
+          // i may not have advanced, which is okay.
+          paused = true;
+          window.document.title = 'okay';
+        });
+      }, 1000);
+    }, 1000);
+  })
+}, 1000);
+
+window.onerror = function() {
+  window.document.title = "error";
+}
+</script>
+
+</body>
+</html>

--- a/stopify/test-data/integration/trivial-pause-and-resume.html
+++ b/stopify/test-data/integration/trivial-pause-and-resume.html
@@ -1,0 +1,33 @@
+<html>
+<body>
+<script src="../../dist/stopify-full.bundle.js"></script>
+<script>
+window.onerror = function() {
+  window.document.title = "error";
+}
+
+const program = `
+  1 + 1;
+`;
+
+const asyncRun = stopify.stopifyLocally(
+  `(function(){ ${program} })()`,
+  { externals: [ ] });
+
+asyncRun.run(() => {
+  // Top-level completed, but this pauses event handlers.
+  asyncRun.pause(() => {
+    console.log('Paused');
+    window.setTimeout(() => {
+      console.log('Resuming ...');
+      asyncRun.resume()
+      if (window.document.title === '') {
+        window.document.title = 'okay';
+      }
+    }, 100);
+  });
+});
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
Right now, if stopified code directly calls addEventListener, things may go very wrong. The problem is that when the browser invokes the event handler, it will start running just fine, but the first time the code suspends, it will crash. This is because stopified code must be invoked in the context of the main runtime loop (i.e., the loop in stopify-continuations/src/callcc/runtime/abstractRuntime.ts).

I suggest we don't support direct calls to addEventListener. Instead, this commit provides an API for external functions to use addEventListener. See clicks.html for a demo program. There are several new integration tests too.