### PR TITLE
Guard switch statements with execution mode and target labels.

### DIFF
--- a/stopify-continuations/src/callcc/jumper.ts
+++ b/stopify-continuations/src/callcc/jumper.ts
@@ -345,6 +345,19 @@ const jumper = {
       bh.and(isNormalMode, path.node.test));
   },
 
+  LabeledStatement: {
+    exit(path: NodePath<Labeled<t.LabeledStatement>>): void {
+      if (isFlat(path)) {
+        return;
+      }
+
+      path.replaceWith(bh.sIf(bh.or(isNormalMode,
+        bh.and(isRestoringMode, labelsIncludeTarget(getLabels(path.node)))),
+        path.node));
+      path.skip();
+    }
+  },
+
   IfStatement: {
     exit(path: NodePath<Labeled<t.IfStatement>>): void {
       if ((<any>path.node).isTransformed || isFlat(path)) {

--- a/stopify/test/should-run/switch-default-return.js
+++ b/stopify/test/should-run/switch-default-return.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const t = 'test';
+
+function bar() {
+  while (false) {}
+}
+
+function foo() {
+  while (false) {}
+  switch (t) {
+    case 'foo':
+      assert(false);
+      break;
+    case 'test':
+      assert(true);
+      break;
+    case 'bar':
+      assert(false);
+      break;
+    default:
+      return 7;
+  }
+  bar();
+  return 8;
+}
+
+assert.equal(foo(), 8);

--- a/stopify/test/should-run/switch-default-throw.js
+++ b/stopify/test/should-run/switch-default-throw.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+const t = 'test';
+
+function bar() {
+  while (false) {}
+}
+
+function foo() {
+  while (false) {}
+  switch (t) {
+    case 'foo':
+      assert(false);
+      break;
+    case 'test':
+      assert(true);
+      break;
+    case 'bar':
+      assert(false);
+      break;
+    default:
+      throw false;
+  }
+  bar();
+}
+
+foo();


### PR DESCRIPTION
Switch statements desugar into labeled statements with a chain of ifs. If the switch contains a `default` case, the body of the labeled statement just appends the `default` case handler to the end of the block (unprotected by an `if`). If a program suspended after the switch statement, the `default` case handler would be run upon restoring the frame. This is an issue if the `default` case contains a `throw` or `return` statement, which are both left unguarded by the jumper transform.

This change guards labeled statements with the pattern below.
```js
if ($__R.mode || !$__R.mode &&(target === 0 || target === 1 || ...))
  _switch: {
    ...
  }
}
```
So the entire switch will be skipped unless the program is restoring to a target within one of the switch cases.