### PR TITLE
Fix for events support constructor handling

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,8 +10,8 @@ source_suffix = ['.rst', '.md']
 # Specify the root of the documentation tree
 master_doc = 'index'
 project = u'Stopify User\'s Manual'
-version = '0.2.0'
-release = '0.2.0'
+version = '0.2.1'
+release = '0.2.1'
 
 # Activate the docs theme
 html_theme = 'sphinx_rtd_theme'

--- a/stopify-continuations/package.json
+++ b/stopify-continuations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stopify-continuations",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Continuations for JavaScript",
   "main": "dist/src/callcc/index",
   "typings": "dist/src/callcc/index",

--- a/stopify-continuations/src/common/desugarNew.ts
+++ b/stopify-continuations/src/common/desugarNew.ts
@@ -25,51 +25,51 @@ import { knowns } from './cannotCapture';
  *
  * }
  */
-const constr = t.identifier('constr');
-const args = t.identifier('args');
-const knownTest = t.callExpression(
-  t.memberExpression(
-    t.memberExpression(t.identifier('$__T'), t.identifier('knownBuiltIns')),
-    t.identifier('includes')),
-  [constr]);
-(<any>knownTest).mark = 'Flat';
-const flatNew = t.newExpression(constr, [t.spreadElement(args)]);
-(<any>flatNew).mark = 'Flat';
-const knownIf = t.ifStatement(knownTest, t.returnStatement(flatNew));
-
-const obj = t.identifier('obj');
-const createCall = t.callExpression(
-  t.memberExpression(t.identifier('Object'), t.identifier('create')),
-  [t.memberExpression(constr, t.identifier('prototype'))]);
-(<any>createCall).mark = 'Flat';
-const createObj = letExpression(obj, createCall, 'const');
-
-const result = t.identifier('result');
-const applyConstr = letExpression(result, t.callExpression(
-  t.memberExpression(constr, t.identifier('apply')), [obj, args]),
-  'const');
-
-const returnObj = t.returnStatement(
-  t.conditionalExpression(
-    t.binaryExpression('===',
-      t.unaryExpression('typeof', result), t.stringLiteral('object')),
-    result, obj));
-
-const handleNewFunction = t.functionDeclaration(
-  t.identifier('handleNew'), [constr, t.restElement(args)],
-  t.blockStatement([
-    knownIf,
-    createObj,
-    applyConstr,
-    returnObj
-  ]));
-
 module.exports = function () {
   return {
     visitor: {
       Program: {
         exit(path: NodePath<t.Program>, state: {opts: CompilerOpts}) {
           if(!state.opts.compileFunction) {
+            const constr = t.identifier('constr');
+            const args = t.identifier('args');
+            const knownTest = t.callExpression(
+              t.memberExpression(
+                t.memberExpression(t.identifier('$__T'), t.identifier('knownBuiltIns')),
+                t.identifier('includes')),
+              [constr]);
+            (<any>knownTest).mark = 'Flat';
+            const flatNew = t.newExpression(constr, [t.spreadElement(args)]);
+            (<any>flatNew).mark = 'Flat';
+            const knownIf = t.ifStatement(knownTest, t.returnStatement(flatNew));
+
+            const obj = t.identifier('obj');
+            const createCall = t.callExpression(
+              t.memberExpression(t.identifier('Object'), t.identifier('create')),
+              [t.memberExpression(constr, t.identifier('prototype'))]);
+            (<any>createCall).mark = 'Flat';
+            const createObj = letExpression(obj, createCall, 'const');
+
+            const result = t.identifier('result');
+            const applyConstr = letExpression(result, t.callExpression(
+              t.memberExpression(constr, t.identifier('apply')), [obj, args]),
+              'const');
+
+            const returnObj = t.returnStatement(
+              t.conditionalExpression(
+                t.binaryExpression('===',
+                  t.unaryExpression('typeof', result), t.stringLiteral('object')),
+                result, obj));
+
+            const handleNewFunction = t.functionDeclaration(
+              t.identifier('handleNew'), [constr, t.restElement(args)],
+              t.blockStatement([
+                knownIf,
+                createObj,
+                applyConstr,
+                returnObj
+              ]));
+
             path.node.body.unshift(handleNewFunction);
           }
         }

--- a/stopify/package.json
+++ b/stopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stopify",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Stopify makes JavaScript a better target language for high-level languages and web-based programming tools",
   "main": "dist/src/index.js",
   "typings": "dist/src/index",

--- a/stopify/test-data/integration/compile-twice.html
+++ b/stopify/test-data/integration/compile-twice.html
@@ -1,0 +1,33 @@
+<html>
+
+<body>
+  <p>This page runs Stopify in the browser.</p>
+<script src="../../dist/stopify-full.bundle.js"></script>
+<script>
+var program = `
+for (var i = 0; i < 10; i++) { };
+`;
+
+var runner = stopify.stopifyLocally(program);
+
+runner.run(() => {
+  console.log('.run completed (1)');
+  var runner = stopify.stopifyLocally(`while(false) { }`);
+  runner.run(() => {
+    console.log('.run completed (2)');
+    window.document.title = 'okay';
+  });
+});
+
+window.setTimeout(() => {
+  console.log('3 second timeout');
+  window.document.title = "error";
+}, 3000);
+
+window.onerror = function() {
+  window.document.title = "error";
+}
+</script>
+
+</body>
+</html>

--- a/stopify/test-data/integration/compile-twice.html
+++ b/stopify/test-data/integration/compile-twice.html
@@ -13,15 +13,19 @@ var runner = stopify.stopifyLocally(program);
 runner.run(() => {
   console.log('.run completed (1)');
   var runner = stopify.stopifyLocally(`while(false) { }`);
-  runner.run(() => {
-    console.log('.run completed (2)');
-    window.document.title = 'okay';
-  });
+  window.setTimeout(() => {
+    runner.run(() => {
+      console.log('.run completed (2)');
+      window.document.title = 'okay';
+    })
+  }, 0);
 });
 
 window.setTimeout(() => {
-  console.log('3 second timeout');
-  window.document.title = "error";
+  if (window.document.title !== 'okay') {
+    console.log('3 second timeout');
+    window.document.title = "error";
+  }
 }, 3000);
 
 window.onerror = function() {


### PR DESCRIPTION
`handleNewFunction` gets stopfied the first time `stopifyLocally` is called in-browser. On subsequent calls, it gets stopified multiple times. This makes `handleNewFunction` a local variable reinstantiated by each visitor, so state does not persist between calls to `stopifyLocally`.