### PR TITLE
Throw exn results from runtime instead of silently continuing.

### DIFF
--- a/stopify-continuations/src/runtime/abstractRuntime.ts
+++ b/stopify-continuations/src/runtime/abstractRuntime.ts
@@ -183,7 +183,7 @@ export abstract class Runtime {
         else if(result.type === 'exception') {
           assert(this.mode,
             `execution completed in restore mode, error was: ${result.value}`);
-          return onDone(result);
+          throw result.value;
         }
         else {
           return unreachable();

--- a/stopify/test-data/integration/top-level-exn.html
+++ b/stopify/test-data/integration/top-level-exn.html
@@ -1,0 +1,41 @@
+<html>
+
+<body>
+  <p>This page runs Stopify in the browser.</p>
+<script src="../../dist/stopify-full.bundle.js"></script>
+<script>
+var bad = false;
+var program = `
+throw 'A';
+bad = true;
+`;
+
+var runner = stopify.stopifyLocally(program, {
+  externals: ['bad']
+ });
+
+window.onerror = function() {
+  window.document.title = "error";
+}
+
+runner.run(() => {
+  if (bad) {
+    window.document.title = 'error';
+    console.error('Code ran after throw');
+  }
+  else {
+    window.document.title = 'okay';
+  }
+});
+
+window.setTimeout(() => {
+  if (window.document.title !== 'okay') {
+    console.log('3 second timeout');
+    window.document.title = "error";
+  }
+}, 3000);
+
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
When delimits are encountered and no delimits are in the queue, delimits are processed immediately. When an exception occurs, the exn is simply returned to the runtime call within the delimit, and is not propogated to the top level, meaning the call to delimit returns normally and the program continues executing. This throws the exn value instead of returning normally.