### PR TITLE
Prototype of stack traces

### DIFF
--- a/stopify-continuations/src/callcc/boxAssignables.ts
+++ b/stopify-continuations/src/callcc/boxAssignables.ts
@@ -223,6 +223,9 @@ const visitor = {
           fastFreshId.fresh('fun'),
           path.node.params,
           path.node.body);
+        if (path.node.id.name !== undefined) {
+          (<any>fun).originalName = path.node.id.name;
+        }
 
         (<any>fun).mark = (<any>path.node).mark;
         (<any>fun).boxedArgs = (<any>path.node).boxedArgs;

--- a/stopify-continuations/src/callcc/captureLogics.ts
+++ b/stopify-continuations/src/callcc/captureLogics.ts
@@ -3,6 +3,7 @@ import * as t from 'babel-types';
 import * as bh from '../babelHelpers';
 import * as fastFreshId from '../fastFreshId';
 import { getLabels } from './label';
+import { CompilerOpts } from '.';
 
 export {
   isNormalMode,
@@ -60,7 +61,8 @@ const pushEagerStack = t.memberExpression(eagerStack, t.identifier('unshift'));
  *      throw exn;
  *    }
  */
-function lazyCaptureLogic(path: NodePath<t.AssignmentExpression>): void {
+function lazyCaptureLogic(path: NodePath<t.AssignmentExpression>,
+  opts: CompilerOpts): void {
   const applyLbl = t.numericLiteral(getLabels(path.node)[0]);
   const exn = fastFreshId.fresh('exn');
 
@@ -94,6 +96,12 @@ function lazyCaptureLogic(path: NodePath<t.AssignmentExpression>): void {
               t.memberExpression(exnStack, t.identifier('length')),
               t.numericLiteral(1)), true)
           ])),
+        ]),
+        t.blockStatement([
+          t.expressionStatement(
+            t.callExpression(
+              t.memberExpression(runtime, t.identifier('pushTrace')),
+              [t.stringLiteral(bh.locationString(path, opts))]))
         ])),
       t.throwStatement(exn)
     ])));
@@ -120,7 +128,8 @@ function lazyCaptureLogic(path: NodePath<t.AssignmentExpression>): void {
  *      eagerStack.shift();
  *    }
  */
-function eagerCaptureLogic(path: NodePath<t.AssignmentExpression>): void {
+function eagerCaptureLogic(path: NodePath<t.AssignmentExpression>,
+  opts: CompilerOpts): void {
   const applyLbl = t.numericLiteral(getLabels(path.node)[0]);
   const nodeStmt = t.expressionStatement(path.node);
 
@@ -177,7 +186,8 @@ function eagerCaptureLogic(path: NodePath<t.AssignmentExpression>): void {
  *      if (mode === 'normal') x = ret;
  *    }
  */
-function retvalCaptureLogic(path: NodePath<t.AssignmentExpression>): void {
+function retvalCaptureLogic(path: NodePath<t.AssignmentExpression>,
+  opts: CompilerOpts): void {
   const applyLbl = t.numericLiteral(getLabels(path.node)[0]);
   const left: any = path.node.left;
 

--- a/stopify-continuations/src/runtime/abstractRuntime.ts
+++ b/stopify-continuations/src/runtime/abstractRuntime.ts
@@ -66,6 +66,12 @@ export abstract class Runtime {
 
   noErrorProvided: any = {};
 
+  /**
+   *  A saved stack trace. This field is only used when a user-mode exception
+   * is thrown.
+   */
+  public stackTrace: string[] = [];
+
   constructor(
     // Maximum number of frames that can be consumed by this runtime.
     public stackSize: number,
@@ -131,7 +137,9 @@ export abstract class Runtime {
         else if(result.type === 'exception') {
           assert(this.mode,
             `execution completed in restore mode, error was: ${result.value}`);
-          return onDone(result);
+          const stack = this.stackTrace;
+          this.stackTrace = [];
+          return onDone({ type: 'exception', value: result.value, stack });
         }
         else {
           return unreachable();
@@ -184,4 +192,8 @@ export abstract class Runtime {
   abstract abstractRun(body: () => any): RunResult;
 
   abstract endTurn(callback: (onDone: (x: Result) => any) => any): never;
+
+  public pushTrace(line: string): void {
+    this.stackTrace.push(line);
+  }
 }

--- a/stopify-continuations/src/types.ts
+++ b/stopify-continuations/src/types.ts
@@ -20,7 +20,7 @@ export interface CompilerOpts {
 
 export type Result =
   { type: 'normal', value: any } |
-  { type: 'exception', value: any };
+  { type: 'exception', value: any, stack: string[] };
 
 export interface Runtime {
   // Remaining number of stacks that this runtime can consume.

--- a/stopify/src/entrypoints/compiler.ts
+++ b/stopify/src/entrypoints/compiler.ts
@@ -54,11 +54,9 @@ export function stopifyLocally(src: string,
   const runtimeOpts = checkAndFillRuntimeOpts(optionalRuntimeOpts || {});
 
   // Copied from ../index.ts
-  if (compileOpts.debug) {
-    const mapConverter = ConvertSourceMap.fromSource(src)!;
-    compileOpts.sourceMap = generateLineMapping(
-      (mapConverter ? mapConverter.toObject() : null) as RawSourceMap);
-  }
+  const mapConverter = ConvertSourceMap.fromSource(src)!;
+  compileOpts.sourceMap = generateLineMapping(
+    (mapConverter ? mapConverter.toObject() : null) as RawSourceMap);
 
   runner = new Runner(compile(src, compileOpts), runtimeOpts);
   return runner;

--- a/stopify/src/index.ts
+++ b/stopify/src/index.ts
@@ -15,11 +15,9 @@ export function stopify(src: string,
     return `${src};window.originalOnDone();`;
   }
   else {
-    if (filledOpts.debug) {
-      const mapConverter = smc.fromSource(src)!;
-      filledOpts.sourceMap = generateLineMapping(
-        (mapConverter ? mapConverter.toObject() : null) as RawSourceMap);
-    }
+    const mapConverter = smc.fromSource(src)!;
+    filledOpts.sourceMap = generateLineMapping(
+      (mapConverter ? mapConverter.toObject() : null) as RawSourceMap);
     return compile(src, filledOpts);
   }
 }

--- a/stopify/src/runtime/abstractRunner.ts
+++ b/stopify/src/runtime/abstractRunner.ts
@@ -77,7 +77,7 @@ export abstract class AbstractRunner implements AsyncRun {
       this.onDone();
     }
     else {
-      this.onDone(result.value);
+      this.onDone({ value: result.value, stack: result.stack });
     }
     this.processQueuedEvents();
   }

--- a/stopify/test-data/integration/exn-stack.trace.html
+++ b/stopify/test-data/integration/exn-stack.trace.html
@@ -1,0 +1,36 @@
+<html>
+
+<body>
+  <p>This page runs Stopify in the browser.</p>
+<script src="../../dist/stopify-full.bundle.js"></script>
+<script>
+var program = `
+function F() {
+    throw new Error('omg');
+}
+
+function G() {
+  F();
+  }
+
+  G();
+`;
+
+var runner = stopify.stopifyLocally(program);
+runner.run((err) => {
+  console.log(err.stack.join("\n"));
+  if (err === 5) {
+    window.document.title = 'okay';
+  }
+  else {
+    window.document.title = "error";
+  }
+});
+
+window.onerror = function() {
+  window.document.title = "error";
+}
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This is not ready to merge, but it gets stack traces mostly working
for lazy continuations. Remaining tasks:

1. Ensure that inserted function calls are not needlessly instrumented
2. Get stack traces to work with eager and retval continuations
3. sourceMap property should be set by stopify-continuations and given
   a type.
4. Determine API change: .run and .processEvent should both return the
   same type of object
5. Document API change
6. Eliminate the $top that appears at the bottom of each trace.