### PR TITLE
Register stopify-continuations source maps

### DIFF
--- a/stopify-continuations/src/compiler/tool.ts
+++ b/stopify-continuations/src/compiler/tool.ts
@@ -11,6 +11,7 @@ import { flatness } from './flatness';
 import { transformFromAst } from '../common/helpers';
 import { CompilerOpts } from '../types';
 import { fastFreshId } from '../callcc/index';
+import 'source-map-support/register';
 
 const visitor: Visitor = {
   Program(path: NodePath<t.Program>, state: CompilerOpts) {


### PR DESCRIPTION
This provides source map support for stopify compile-time errors within the `stopify-continuations` workspace, which is useful when hacking on the typescript program transformations.

Source maps are already registered in the `stopify` workspace in `stopify/src/compile.ts`.