### PR TITLE
Try catch capture logic

### DIFF
--- a/stopify-continuations/bin/build
+++ b/stopify-continuations/bin/build
@@ -9,7 +9,7 @@ mkdir -p dist/tmp
 
 echo 'Generating pre-stopififed runtimes'
 
-for TRANSFORM in lazy eager retval fudge; do
+for TRANSFORM in lazy catch eager retval fudge; do
   ./bin/stopify-continuations.js -t $TRANSFORM dist/src/runtime/implicitApps.js dist/tmp/implicitApps.$TRANSFORM.js
   ./bin/stopify-continuations.js -t $TRANSFORM dist/src/runtime/hofs.js dist/tmp/hofs.$TRANSFORM.js
 done

--- a/stopify-continuations/js/webpack.config.js
+++ b/stopify-continuations/js/webpack.config.js
@@ -21,7 +21,7 @@ const stopifyContinuations = {
 };
 targets.push(stopifyContinuations);
 
-for (const transform of [ 'lazy', 'eager', 'retval', 'fudge' ]) {
+for (const transform of [ 'lazy', 'catch', 'eager', 'retval', 'fudge' ]) {
   targets.push({
     entry: `./dist/tmp/implicitApps.${transform}.js`,
     output: {

--- a/stopify-continuations/src/callcc/callcc.ts
+++ b/stopify-continuations/src/callcc/callcc.ts
@@ -88,7 +88,7 @@ const visitor: Visitor = {
     timeSlow('desugar logical', () =>
       h.transformFromAst(path, [desugarLogical]));
     timeSlow('ANF', () =>
-      h.transformFromAst(path, [anf]));
+      h.transformFromAst(path, [[anf, opts]]));
     timeSlow('declVars', () =>
       h.transformFromAst(path, [declVars]));
     // If stopifying eval'd string at runtime, don't delimit statements so that

--- a/stopify-continuations/src/callcc/callcc.ts
+++ b/stopify-continuations/src/callcc/callcc.ts
@@ -100,19 +100,6 @@ const visitor: Visitor = {
 
     path.stop();
 
-    let toShift;
-    if (opts.compileFunction) {
-      if (t.isFunctionDeclaration(path.node.body[0])) {
-        toShift = (<t.FunctionDeclaration>path.node.body[0]).body.body;
-      }
-      else {
-        throw new Error('Top-level function expected');
-      }
-    }
-    else {
-      toShift = path.node.body;
-    }
-
     if (!doNotWrap) {
       // $__R.runtime($top, opts.onDone);
       path.node.body.push(t.expressionStatement(
@@ -120,19 +107,6 @@ const visitor: Visitor = {
           t.memberExpression($__R, t.identifier('runtime')),
           [$top, opts.onDone])));
     }
-
-    toShift.unshift(
-      h.letExpression(
-        t.identifier("suspendCC"),
-        t.memberExpression(t.identifier("$__R"), t.identifier("suspendCC")),
-        "var"));
-    toShift.unshift(
-      h.letExpression(
-        t.identifier("captureCC"),
-        t.callExpression(
-          t.memberExpression(t.memberExpression(t.identifier("$__R"),
-            t.identifier("captureCC")), t.identifier("bind")), [$__R]),
-        "var"));
 
     if (!state.opts.compileFunction) {
       path.node.body.unshift(

--- a/stopify-continuations/src/callcc/captureLogics.ts
+++ b/stopify-continuations/src/callcc/captureLogics.ts
@@ -126,7 +126,13 @@ function lazyGlobalCatch(path: NodePath<t.AssignmentExpression>,
     const nodeStmt = t.expressionStatement(path.node);
 
     const restoreNode = t.assignmentExpression(path.node.operator,
-      path.node.left, stackFrameCall);
+      path.node.left, t.callExpression(t.memberExpression(t.memberExpression(
+        topOfRuntimeStack, t.identifier('f')),
+        t.identifier('apply')), [
+          t.memberExpression(topOfRuntimeStack, t.identifier('this')),
+          t.memberExpression(topOfRuntimeStack, t.identifier('params'))
+        ]));
+
     const ifStmt = t.ifStatement(isNormalMode,
       t.blockStatement([
         t.expressionStatement(t.assignmentExpression('=', target, applyLbl)),

--- a/stopify-continuations/src/callcc/jumper.ts
+++ b/stopify-continuations/src/callcc/jumper.ts
@@ -226,11 +226,16 @@ function func(path: NodePath<Labeled<FunctionT>>, state: State): void {
     const exn = fresh('exn');
     const exnStack = t.memberExpression(exn, t.identifier('stack'));
 
+    const params = path.node.__usesArgs__
+      ?  matArgs :  t.arrayExpression(path.node.params.map(paramToArg));
+
     const captureObject: t.ObjectProperty[] = [
       t.objectProperty(t.identifier('kind'), t.stringLiteral('rest')),
-      t.objectProperty(t.identifier('f'), restoreNextFrame),
+      t.objectProperty(t.identifier('f'), path.node.id),
       t.objectProperty(t.identifier('index'), target),
       t.objectProperty(t.identifier('locals'), t.arrayExpression(restoreLocals)),
+      t.objectProperty(t.identifier('params'), params),
+      t.objectProperty(t.identifier('this'), t.thisExpression()),
     ];
 
     if (path.node.__usesArgs__ && state.opts.jsArgs === 'full') {
@@ -256,7 +261,6 @@ function func(path: NodePath<Labeled<FunctionT>>, state: State): void {
       ...(state.opts.jsArgs === 'full' ? [defineArgsLen] : []),
       decreaseStackSize,
       ifRestoring,
-      reenterClosure,
       ...mayMatArgs,
       wrapBody,
     ]);

--- a/stopify-continuations/src/common/anf.ts
+++ b/stopify-continuations/src/common/anf.ts
@@ -11,6 +11,7 @@ import { NodePath, Visitor } from 'babel-traverse';
 import * as t from 'babel-types';
 import * as h from './helpers';
 import * as fastFreshId from '../fastFreshId';
+import { CompilerOpts } from '../types';
 
 function withinTryBlock(path: NodePath<t.Node>): boolean {
   const funOrTryParent = path.findParent(p => p.isFunction() || p.isTryStatement());
@@ -62,13 +63,14 @@ const anfVisitor : Visitor = {
       }
     },
 
-    exit(path: NodePath<t.CallExpression>): void {
+    exit(path: NodePath<t.CallExpression>, state: { opts: CompilerOpts }): void {
       if ((<any>path.node.callee).mark === 'Flat') {
         return;
       }
       const p = path.parent;
       if ((!t.isVariableDeclarator(p) &&
-        !t.isReturnStatement(p)) ||
+        (!t.isReturnStatement(p) ||
+          state.opts.captureMethod === 'catch')) ||
         (t.isReturnStatement(p) &&
           withinTryBlock(path))) {
         // Name the function application if it is not already named or

--- a/stopify-continuations/src/compiler/check-compiler-opts.ts
+++ b/stopify-continuations/src/compiler/check-compiler-opts.ts
@@ -113,8 +113,8 @@ export function checkAndFillCompilerOpts(
     (x) => typeof x === 'boolean',
     `.debug must be a boolean`);
   copyProp(opts, value, 'captureMethod',
-    (x) => ['lazy', 'eager', 'retval', 'original', 'fudge'].includes(x),
-    `.captureMethod must be 'lazy', 'eager', 'retval', 'original', or 'fudge'`);
+    (x) => ['lazy', 'catch', 'eager', 'retval', 'original', 'fudge'].includes(x),
+    `.captureMethod must be 'lazy', 'catch', 'eager', 'retval', 'original', or 'fudge'`);
   copyProp(opts, value, 'newMethod',
     (x) => ['direct', 'wrapper'].includes(x),
     `.newMethod must be 'direct' or 'wrapper'`);

--- a/stopify-continuations/src/compiler/parse-compiler-opts.ts
+++ b/stopify-continuations/src/compiler/parse-compiler-opts.ts
@@ -7,7 +7,7 @@ import { checkAndFillCompilerOpts } from './check-compiler-opts';
 
 commander.option(
   '-t, --transform <transformation>',
-  'either eager, lazy, retval, original, or fudge');
+  'either eager, lazy, catch, retval, original, or fudge');
 
 commander.option(
   '-n, --new <new>',

--- a/stopify-continuations/src/runtime/runtime.ts
+++ b/stopify-continuations/src/runtime/runtime.ts
@@ -17,6 +17,7 @@ export function newRTS(transform: string): Runtime {
   if (!savedRTS) {
     switch (transform) {
       // Default to shallow runtime.
+      case 'catch':
       case 'lazy': savedRTS = new LazyRuntime(Infinity, Infinity); break;
       case 'eager': savedRTS = new EagerRuntime(Infinity, Infinity); break;
       case 'retval': savedRTS = new RetvalRuntime(Infinity, Infinity); break;

--- a/stopify-continuations/src/types.ts
+++ b/stopify-continuations/src/types.ts
@@ -1,5 +1,5 @@
 import * as t from 'babel-types';
-export type CaptureMethod = 'eager' | 'retval' | 'lazy' | 'original' | 'fudge';
+export type CaptureMethod = 'eager' | 'retval' | 'lazy' | 'catch' | 'original' | 'fudge';
 export type HandleNew = 'direct' | 'wrapper';
 
 export interface LineMapping {

--- a/stopify/test/should-run.test.ts
+++ b/stopify/test/should-run.test.ts
@@ -9,6 +9,7 @@ describe('call/cc', function() {
     f.callCCTest(filename, `-t lazy --new direct ${copts}`, ropts);
     f.callCCTest(filename, `-t retval ${copts}`, ropts);
     f.callCCTest(filename, `-t eager ${copts}`, ropts);
+    f.callCCTest(filename, `-t catch ${copts}`, ropts);
 
     // Deep stacks tests.
     f.callCCTest(filename, `-t lazy ${copts}`,


### PR DESCRIPTION
Wraps function bodies in a top-level try/catch rather than each individual application. Leaving it for future work to merge this logic with `-t lazy` to instrument function bodies according to whether or not they contain tail calls.