### PR TITLE
An API for external higher-order functions

### DIFF
--- a/stopify-continuations/src/runtime/eagerRuntime.ts
+++ b/stopify-continuations/src/runtime/eagerRuntime.ts
@@ -10,17 +10,20 @@ export class EagerRuntime extends common.Runtime {
     this.eagerStack = [];
   }
 
-  captureCC(f: (k: any) => any) {
+  captureCC(f: (k: (x: Result) => any) => any): any {
     this.capturing = true;
     throw new common.Capture(f, [...this.eagerStack]);
   }
 
   makeCont(stack: common.Stack) {
-    return (v: any, err: any=this.noErrorProvided) => {
-      var throwExn = err !== this.noErrorProvided;
+    return (x: Result) => {
       let restarter = () => {
-        if(throwExn) { throw err; }
-        else { return v; }
+        if (x.type === 'exception') {
+          throw x.value;
+        }
+        else {
+          return x.value;
+        }
       };
       this.eagerStack = [...stack];
       throw new common.Restore([this.topK(restarter), ...stack], []);

--- a/stopify-continuations/src/runtime/lazyRuntime.ts
+++ b/stopify-continuations/src/runtime/lazyRuntime.ts
@@ -7,7 +7,7 @@ export class LazyRuntime extends common.Runtime {
     super(stackSize, restoreFrames);
   }
 
-  captureCC(f: (k: any) => any): void {
+  captureCC(f: (k: (x: Result) => any) => any): any {
     this.capturing = true;
     throw new common.Capture(f, []);
   }
@@ -20,11 +20,14 @@ export class LazyRuntime extends common.Runtime {
       savedStack.push(stack.pop()!);
     }
 
-    return (v: any, err: any=this.noErrorProvided) => {
-      const throwExn = err !== this.noErrorProvided;
+    return (x: Result) => {
       let restarter = () => {
-        if(throwExn) { throw err; }
-        else { return v; }
+        if (x.type === 'exception') {
+          throw x.value;
+        }
+        else {
+          return x.value;
+        }
       };
       throw new common.Restore([this.topK(restarter), ...stack], savedStack);
     };

--- a/stopify-continuations/src/runtime/retvalRuntime.ts
+++ b/stopify-continuations/src/runtime/retvalRuntime.ts
@@ -7,7 +7,7 @@ export class RetvalRuntime extends common.Runtime {
     super(stackSize, restoreFrames);
   }
 
-  captureCC(f: (k: any) => any): common.Capture {
+  captureCC(f: (k: (x: Result) => any) => any): any {
     this.capturing = true;
     return new common.Capture(f, []);
   }
@@ -19,13 +19,15 @@ export class RetvalRuntime extends common.Runtime {
       savedStack.push(stack.pop()!);
     }
 
-    return (v: any, err: any=this.noErrorProvided) => {
-      const throwExn = err !== this.noErrorProvided;
+    return (x: Result) => {
       let restarter = () => {
-        if (throwExn) { throw err; }
-        else { return v; }
+        if (x.type === 'exception') {
+          throw x.value;
+        }
+        else {
+          return x.value;
+        }
       };
-
       return new common.Restore([this.topK(restarter), ...stack], savedStack);
     };
   }

--- a/stopify-continuations/src/types.ts
+++ b/stopify-continuations/src/types.ts
@@ -44,5 +44,5 @@ export interface Runtime {
   runtime<T>(body: () => any, onDone: (x: Result) => T): T;
 
   // Called when the stack needs to be captured.
-  captureCC(f: (k: any) => any): void;
+  captureCC(f: (k: (x: Result) => any) => any): void;
 }

--- a/stopify/src/types.ts
+++ b/stopify/src/types.ts
@@ -37,4 +37,10 @@ export interface AsyncRun {
   pauseImmediate(callback: () => void): void;
   continueImmediate(result: any): void;
   processEvent(body: () => any, receiver: (x: Result) => void): void;
+
+  /** Start an external higher-order function. */
+  externalHOF(body: (complete: (result: Result) => void) => never): void;
+
+  /** Run Stopified code from an external higher-order function. */
+  runStopifiedCode(body: () => void, callback: (x: Result) => void): void;
 }

--- a/stopify/test-data/integration/external-hof.html
+++ b/stopify/test-data/integration/external-hof.html
@@ -1,0 +1,56 @@
+<html>
+
+<body>
+  <p>This page runs Stopify in the browser.</p>
+<script src="../../dist/stopify-full.bundle.js"></script>
+<script>
+
+// Without Stopify, this function would be:
+// function(f) { return f(20) + 300; }
+window.externalFunction = function(f) {
+  runner.externalHOF(complete => {
+    runner.runStopifiedCode(
+      () => f(20), 
+      (result) => {
+        if (result.type === 'normal') {
+          complete({ type: 'normal', value: result.value + 300 });
+        }
+        else {
+          complete(result);
+        }
+      });
+  });
+}
+
+var x = 0;
+
+function setResult(_x) {
+  x = _x;
+}
+
+var program = `
+  setResult(4000 + externalFunction(function(x) { return x + 1; }));
+`;
+
+var runner = stopify.stopifyLocally(program, {
+  externals: ['externalFunction', 'setResult' ]
+});
+
+runner.run((result) => {
+  if (result.type === 'normal' && x === 4321) {
+    window.document.title = 'okay';
+    console.info('okay');
+    return;
+  }
+
+  console.error(result);
+  window.document.title = "error";
+});
+
+window.onerror = function() {
+  window.document.title = "error";
+}
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Our current approach to dealing with external higher-order functions
is to apply stopify-continuations to the external library. This is
not always desirable. This commit introduces an API for defining
external higher-order functions. It is a little clunky, but I don't
there is a way around that.