### PR TITLE
Add a new callback-based pause function on AsyncRun

### DIFF
--- a/stopify/package.json
+++ b/stopify/package.json
@@ -20,7 +20,7 @@
     "@types/tmp": "0.0.33",
     "@types/webpack": "^3.0.5",
     "browserify": "^16.1.0",
-    "chromedriver": "^2.46.0",
+    "chromedriver": "76.0.0",
     "geckodriver": "^1.16.0",
     "glob": "^7.1.1",
     "jest": "^24.7.1",

--- a/stopify/src/runtime/abstractRunner.ts
+++ b/stopify/src/runtime/abstractRunner.ts
@@ -197,9 +197,21 @@ export abstract class AbstractRunner implements AsyncRun {
     this.suspendRTS.resumeFromCaptured();
   }
 
+  // NOTE: In both of the pause functions below, we don't switch the mode to
+  // paused! This is because we don't want the user to be able to hit "step" at
+  // this point.
+
+  pauseK(callback: (k: (r: Result) => void) => void): void {
+    return this.continuationsRTS.captureCC((k) => {
+      return this.continuationsRTS.endTurn(onDone => {
+        return callback((x : Result) => {
+          return this.continuationsRTS.runtime(() => k(x), onDone);
+        });
+      });
+    });
+  }
+
   pauseImmediate(callback: () => void): void {
-    // NOTE: We don't switch the mode to paused! This is because we don't want
-    // the user to be able to hit "step" at this point.
     return this.continuationsRTS.captureCC((k) => {
       return this.continuationsRTS.endTurn(onDone => {
         this.k = { k, onDone };

--- a/stopify/src/types.ts
+++ b/stopify/src/types.ts
@@ -47,6 +47,7 @@ export interface AsyncRun {
   resume(): void;
   setBreakpoints(line: number[]): void;
   step(onStep: (line: number) => void): void;
+  pauseK(callback: (k: (r: Result) => void) => void): void;
   pauseImmediate(callback: () => void): void;
   continueImmediate(result: Result): void;
   processEvent(body: () => any, receiver: (x: Result) => void): void;

--- a/stopify/test-data/integration/pause-callback-style.html
+++ b/stopify/test-data/integration/pause-callback-style.html
@@ -1,0 +1,53 @@
+<html>
+
+<body>
+  <p>This page runs Stopify in the browser.</p>
+<script src="../../dist/stopify-full.bundle.js"></script>
+<script>
+var program = `
+inspect.x = fiblarious(5);
+`;
+
+function fiblarious(n) {
+  if(n === 0) { return 1; }
+  if(n === 1) { return 1; }
+  runner.pauseK((restart) => {
+    window.setTimeout(() => {
+      runner.evalAsync(`fiblarious(${n - 1})`, (result1) => {
+        runner.evalAsync(`fiblarious(${n - 2})`, (result2) => {
+          console.log(result1, result2);
+          restart({type: 'normal', value: result1.value + result2.value});
+        });
+      });
+    }, 0);
+  });
+}
+
+
+var runner = stopify.stopifyLocally(program, { }, {
+  estimator: 'countdown',
+  yieldInterval: 1
+});
+
+runner.g.window = window;
+runner.g.console = console;
+runner.g.fiblarious = fiblarious;
+runner.g.inspect = {};
+
+runner.run((result) => {
+  if (result.type !== 'normal' || runner.g.inspect.x !== 8) {
+    console.error(`result: `, result, runner.g.inspect);
+    window.document.title = 'error';
+  }
+  else {
+    console.log("Success: after fibs:", result, runner.g.inspect);
+  }
+});
+
+window.onerror = function() {
+  window.document.title = "error";
+}
+</script>
+
+</body>
+</html>

--- a/stopify/test-data/integration/pause-callback-style.html
+++ b/stopify/test-data/integration/pause-callback-style.html
@@ -40,6 +40,7 @@ runner.run((result) => {
     window.document.title = 'error';
   }
   else {
+    window.document.title = 'okay';
     console.log("Success: after fibs:", result, runner.g.inspect);
   }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -494,6 +494,15 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/glob@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
+  integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
+  dependencies:
+    "@types/events" "*"
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz#1eb8c033e98cf4e1a4cedcaf8bcafe8cb7591e85"
@@ -1865,12 +1874,12 @@ chrome-trace-event@^1.0.0:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^2.46.0:
-  version "2.46.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-2.46.0.tgz#3d78e7eb9bb65dd804fe327a6bf76fced12be053"
-  integrity sha512-dLtKIJW3y/PuFrPmcw6Mb8Nh+HwSqgVrK1rWgTARXhHfWvV822X2VRkx2meU/tg2+YQL6/nNgT6n5qWwIDHbwg==
+chromedriver@76.0.0:
+  version "76.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-76.0.0.tgz#cbf618c5b370799ff6e15b23de07e80f67f89025"
+  integrity sha512-jGyqs0N+lMo9iaNQxGKNPiLJWb2L9s2rwbRr1jJeQ37n6JQ1+5YMGviv/Fx5Z08vBWYbAvrKEzFsuYf8ppl+lw==
   dependencies:
-    del "^3.0.0"
+    del "^4.1.1"
     extract-zip "^1.6.7"
     mkdirp "^0.5.1"
     request "^2.88.0"
@@ -2414,17 +2423,18 @@ defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
 
-del@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
-  integrity sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=
+del@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/del/-/del-4.1.1.tgz#9e8f117222ea44a31ff3a156c049b99052a9f0b4"
+  integrity sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==
   dependencies:
+    "@types/glob" "^7.1.1"
     globby "^6.1.0"
-    is-path-cwd "^1.0.0"
-    is-path-in-cwd "^1.0.0"
-    p-map "^1.1.1"
-    pify "^3.0.0"
-    rimraf "^2.2.8"
+    is-path-cwd "^2.0.0"
+    is-path-in-cwd "^2.0.0"
+    p-map "^2.0.0"
+    pify "^4.0.1"
+    rimraf "^2.6.3"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -4057,24 +4067,24 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-path-cwd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
-  integrity sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
+is-path-cwd@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
+  integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
 
-is-path-in-cwd@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
-  integrity sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==
+is-path-in-cwd@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz#bfe2dca26c69f397265a4009963602935a053acb"
+  integrity sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==
   dependencies:
-    is-path-inside "^1.0.0"
+    is-path-inside "^2.1.0"
 
-is-path-inside@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
-  integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
+is-path-inside@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-2.1.0.tgz#7c9810587d659a40d27bcdb4d5616eab059494b2"
+  integrity sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==
   dependencies:
-    path-is-inside "^1.0.1"
+    path-is-inside "^1.0.2"
 
 is-plain-obj@^1.0.0:
   version "1.1.0"
@@ -5700,9 +5710,10 @@ p-locate@^3.0.0:
   dependencies:
     p-limit "^2.0.0"
 
-p-map@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.1.1.tgz#05f5e4ae97a068371bc2a5cc86bfbdbc19c4ae7a"
+p-map@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
+  integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
 
 p-reduce@^1.0.0:
   version "1.0.0"
@@ -5810,7 +5821,7 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1:
+path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
@@ -6573,7 +6584,7 @@ rimraf@2, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
-rimraf@^2.2.8, rimraf@^2.6.2:
+rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==


### PR DESCRIPTION
The idea here is to give the caller of pause a callback that closes over the
continuation, instead of stashing it in a field on the runner. That way each
call to pause can restart independently without depending on any others, and
multiple stacks can be tracked.

This is especially useful for nested pause/restart computations, which don't
work well with only a single field to store the continuation.

@arjunguha can you point me to the right place to add a test? This works with the nested require/eval work now.