### PR TITLE
Break AsyncRun into more exposed functions

### DIFF
--- a/stopify/src/entrypoints/compiler.ts
+++ b/stopify/src/entrypoints/compiler.ts
@@ -60,10 +60,23 @@ class Runner extends AbstractRunner {
     eval.call(global, this.code);
   }
 
-  evalAsyncFromAst(ast: t.Program, onDone: (result: Result) => void): void {
-    const stopifiedCode = compileFromAst(ast, this.evalOpts);
+  compile(src: string): string {
+    const ast = babylon.parse(src).program;
+    return compileFromAst(ast, this.evalOpts);
+  }
+
+  compileFromAst(ast: t.Program): string {
+    return compileFromAst(ast, this.evalOpts);
+  }
+
+  evalCompiled(stopifiedCode: string, onDone: (result: Result) => void): void {
     this.eventMode = EventProcessingMode.Running;
     this.continuationsRTS.runtime(eval(stopifiedCode), onDone);
+  }
+
+  evalAsyncFromAst(ast: t.Program, onDone: (result: Result) => void): void {
+    const stopifiedCode = compileFromAst(ast, this.evalOpts);
+    this.evalCompiled(stopifiedCode, onDone);
   }
 
   evalAsync(src: string, onDone: (result: Result) => void): void {

--- a/stopify/test-data/integration/compile-then-eval.html
+++ b/stopify/test-data/integration/compile-then-eval.html
@@ -1,0 +1,38 @@
+<html>
+
+<body>
+  <p>This page runs Stopify in the browser.</p>
+<script src="../../dist/stopify-full.bundle.js"></script>
+<script>
+var program = `
+inspect.x = tester();
+`;
+
+var runner = stopify.stopifyLocally(program);
+
+function tester() {
+  const stopifiedCode = runner.compile("37");
+  runner.pauseK((resume) => {
+    runner.evalCompiled(stopifiedCode, (result) => {
+      resume(result);
+    });
+  });
+}
+
+runner.g.inspect = {};
+runner.g.tester = tester;
+
+runner.run((result) => {
+  if(runner.g.inspect.x != 37) {
+    window.document.title = "error";
+    console.error(result, runner.g.inspect);
+  }
+  else {
+    window.document.title = "ok";
+  }
+});
+
+</script>
+
+</body>
+</html>

--- a/stopify/test-data/integration/compile-then-eval.html
+++ b/stopify/test-data/integration/compile-then-eval.html
@@ -28,7 +28,7 @@ runner.run((result) => {
     console.error(result, runner.g.inspect);
   }
   else {
-    window.document.title = "ok";
+    window.document.title = "okay";
   }
 });
 


### PR DESCRIPTION
This enables a user to save stopified code generated from a runner before doing
an eval, in order to support caching, inspect the stopified result themselves,
do some custom evaluation, etc.