### PR TITLE
Remove null variable declaration in conditional expression.

### DIFF
--- a/normalize-js/test/unit-tests.test.ts
+++ b/normalize-js/test/unit-tests.test.ts
@@ -570,3 +570,15 @@ test('uninitialized variable', () => {
         t;
     `);
 });
+
+test('compound conditional', () => {
+    normalizeEquiv(`
+        function F(x) {
+            return x;
+        }
+        let i = 0;
+        if(F(true) && F(true) || F(false)) {
+            i++;
+        }
+    `);
+});

--- a/normalize-js/ts/desugarLogical.ts
+++ b/normalize-js/ts/desugarLogical.ts
@@ -39,7 +39,7 @@ export const visitor: Visitor = {
     const r = fresh(op === "&&" ? "and" : "or");
 
     stmt.insertBefore(
-      t.variableDeclaration("let", [t.variableDeclarator(r)]));
+      t.variableDeclaration("let", [t.variableDeclarator(r, t.identifier("undefined"))]));
 
     const x = t.blockStatement([t.expressionStatement(
       t.assignmentExpression("=", r, path.node.right))]);

--- a/stopify/package.json
+++ b/stopify/package.json
@@ -20,7 +20,7 @@
     "@types/tmp": "0.0.33",
     "@types/webpack": "^3.0.5",
     "browserify": "^16.1.0",
-    "chromedriver": "76.0.0",
+    "chromedriver": "79.0.0",
     "geckodriver": "^1.16.0",
     "glob": "^7.1.1",
     "jest": "^24.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1874,10 +1874,10 @@ chrome-trace-event@^1.0.0:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@76.0.0:
-  version "76.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-76.0.0.tgz#cbf618c5b370799ff6e15b23de07e80f67f89025"
-  integrity sha512-jGyqs0N+lMo9iaNQxGKNPiLJWb2L9s2rwbRr1jJeQ37n6JQ1+5YMGviv/Fx5Z08vBWYbAvrKEzFsuYf8ppl+lw==
+chromedriver@79.0.0:
+  version "79.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-79.0.0.tgz#1660ac29924dfcd847911025593d6b6746aeea35"
+  integrity sha512-DO29C7ntJfzu6q1vuoWwCON8E9x5xzopt7Q41A7Dr7hBKcdNpGw1l9DTt9b+l1qviOWiJLGsD+jHw21ptEHubA==
   dependencies:
     del "^4.1.1"
     extract-zip "^1.6.7"


### PR DESCRIPTION
Ran into this issue when working on a project that employs normalize-js. This change changes:

```
    let x01 = F(true);
    let and0;
    
    if (x01) {
      let app0 = F(true);
      and0 = app0;
    } else {
      and0 = x01;
    }
```

to:

```
    let x01 = F(true);
    let and0 = undefined; // <--
    
    if (x01) {
      let app0 = F(true);
      and0 = app0;
    } else {
      and0 = x01;
    }
```