### PR TITLE
Add detection for whether we are on an active Stopify stack

### DIFF
--- a/stopify-continuations/src/types.ts
+++ b/stopify-continuations/src/types.ts
@@ -47,6 +47,7 @@ export interface Runtime {
 
   mode: Mode;
   stack: Stack;
+  stackActive: boolean;
 
   endTurn(callback: (onDone: (x: Result) => any) => any): never;
 

--- a/stopify/src/runtime/abstractRunner.ts
+++ b/stopify/src/runtime/abstractRunner.ts
@@ -240,6 +240,10 @@ export abstract class AbstractRunner implements AsyncRun {
     this.continuationsRTS.runtime(body, callback);
   }
 
+  isRunning(): boolean {
+    return this.continuationsRTS.stackActive;
+  }
+
   processEvent(body: () => void, receiver: (x: Result) => void): void {
     this.eventQueue.push({ body, receiver } );
     this.processQueuedEvents();

--- a/stopify/src/types.ts
+++ b/stopify/src/types.ts
@@ -45,6 +45,7 @@ export interface AsyncRun {
     onBreakpoint?: (line: number) => void): void;
   pause(onPaused: (line?: number) => void): void;
   resume(): void;
+  isRunning(): boolean;
   setBreakpoints(line: number[]): void;
   step(onStep: (line: number) => void): void;
   pauseK(callback: (k: (r: Result) => void) => void): void;

--- a/stopify/test/semantics.test.ts
+++ b/stopify/test/semantics.test.ts
@@ -282,6 +282,38 @@ describe('integration tests', function () {
     }
 });
 
+describe('Test cases that check running status',() => {
+    test('Running status should be paused (not running) in synchronous code after starting to run', onDone => {
+        const runner = harness(`
+            function sum(x) {
+                if (x % 20 === 0) { checkRunning(); }
+                if (x % 30 === 0) { pauseAndCheckRunning(); }
+                if (x <= 1) {
+                    return 1;
+                } else {
+                    return x + sum(x-1);
+                }
+            }
+            assert.equal(sum(100), 5050);
+            `, { captureMethod: 'lazy' });
+        runner.g.checkRunning = function() {
+            assert.equal(runner.isRunning(), true);
+        };
+        runner.g.pauseAndCheckRunning = function() {
+            runner.pauseK(k => {
+                assert.equal(runner.isRunning(), false);
+                k({ type: 'normal', value: 'restart' });
+            });
+        };
+        runner.run(result => {
+            expect(result).toEqual({ type: 'normal' });
+            onDone();
+        expect(runner.isRunning()).toBe(false);
+        });
+    }, 10000);
+
+});
+
 describe('Test cases that require deep stacks',() => {
     const runtimeOpts: Partial<types.RuntimeOpts> = {
         stackSize: 100,


### PR DESCRIPTION
(Sorry about accidentally creating a branch on the main Stopify repo; just meant to make this PR)

Adds a stackActive field to abstractRuntime that tracks whether the JavaScript stack is currently using Stopified frames, and exposes it through isRunning() on abstractRuntime.

The use case for this, beyond it being a likely-useful utility, is writing polyfills for HOFs that can switch on and off depending on if they can expect to capture or not.

We've done some of this work for Pyret
(https://github.com/brownplt/pyret-lang/blob/8e0ce78fb0ca1c10bcc06dfcaeb534d0ae2c02e4/src/runtime/hof-array-polyfill.ts#L347) because the Pyret runtime co-exists on a page with regular old React code.

Because everything in React and in the Stopified runtime is getting asynchronously chopped up and scheduled all over the place, and because we want JS arrays to be arrays whether in the stopify runtime or the page runtime, it's useful to have polyfills that automatically do the right thing. This avoids these problems:

- If using the default array polyfill strategy from Stopify, non-stopified code can get access to arrays with stopified map/filter/fold. Say that's called in some `didComponentUpdate` or other scheduled React event – now it's not on a Stopify stack and lots of e.g. uncaught Captures result. It is really, really hard to remember that every array may or may not be from the Stopify runtime and have a different prototype.
- When calling into Stopified code, it's natural to want to pass in “regular” arrays. It's also hard to remember and design APIs around introducing wrapping on these as they *enter* stopified code.
- The flag lets us handle cases like:
  - A didComponentUpdate starts a Pyret evaluation for e.g. rendering a Pyret value to a React element, which calls back into some Stopified Pyret code. This goes in a suitable wrapper.
  - That code suspends for whatever reason, yielding control back to didComponentUpdate, which uses e.g. map/filter/fold. The map/filter/fold in didComponentUpdate will correctly use the plain, un-instrumented map/filter/fold.
  - The Stopified code resumes in the next turn and does map/filter/fold in the dynamic extent of the Pyret code. This correctly uses the stopified versions of the HOFs.